### PR TITLE
Enable AnomalyScoreMeanVarThreshold based on three-sigma 

### DIFF
--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -153,6 +153,9 @@ class AnomalibDataModule(LightningDataModule, ABC):
         elif self.val_split_mode == ValSplitMode.SAME_AS_TEST:
             # equal to test set
             self.val_data = self.test_data
+        elif self.val_split_mode == ValSplitMode.SAME_AS_TRAIN:
+            # equal to train set, this is only for AnomalyScoreMeanVarThreshold
+            self.val_data = self.train_data
         elif self.val_split_mode == ValSplitMode.SYNTHETIC:
             # converted from random training sample
             self.train_data, normal_val_data = random_split(self.train_data, self.val_split_ratio, seed=self.seed)

--- a/src/anomalib/data/utils/split.py
+++ b/src/anomalib/data/utils/split.py
@@ -46,6 +46,7 @@ class ValSplitMode(str, Enum):
     NONE = "none"
     SAME_AS_TEST = "same_as_test"
     FROM_TEST = "from_test"
+    SAME_AS_TRAIN = "same_as_train"
     SYNTHETIC = "synthetic"
 
 

--- a/src/anomalib/models/components/base/anomaly_module.py
+++ b/src/anomalib/models/components/base/anomaly_module.py
@@ -56,7 +56,9 @@ class AnomalyModule(pl.LightningModule, ABC):
         self.image_threshold = MethodToThrehsoldMapping.get(threshold_config.method, AnomalyScoreThreshold)(
             **threshold_config
         ).cpu()
-        self.pixel_threshold = AnomalyScoreThreshold(**threshold_config).cpu()
+        self.pixel_threshold = MethodToThrehsoldMapping.get(threshold_config.method, AnomalyScoreThreshold)(
+            **threshold_config
+        ).cpu()
 
         self.normalization_metrics: Metric
 

--- a/src/anomalib/models/components/base/anomaly_module.py
+++ b/src/anomalib/models/components/base/anomaly_module.py
@@ -22,11 +22,17 @@ from anomalib.post_processing import ThresholdMethod
 from anomalib.utils.metrics import (
     AnomalibMetricCollection,
     AnomalyScoreDistribution,
+    AnomalyScoreMeanVarThreshold,
     AnomalyScoreThreshold,
     MinMax,
 )
 
 logger = logging.getLogger(__name__)
+
+MethodToThrehsoldMapping = {
+    ThresholdMethod.ADAPTIVE: AnomalyScoreThreshold,
+    ThresholdMethod.MEANVAR: AnomalyScoreMeanVarThreshold,
+}
 
 
 class AnomalyModule(pl.LightningModule, ABC):
@@ -35,7 +41,7 @@ class AnomalyModule(pl.LightningModule, ABC):
     Acts as a base class for all the Anomaly Modules in the library.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, **kwargs) -> None:
         super().__init__()
         logger.info("Initializing %s model.", self.__class__.__name__)
 
@@ -45,8 +51,12 @@ class AnomalyModule(pl.LightningModule, ABC):
         self.callbacks: list[Callback]
 
         self.threshold_method: ThresholdMethod
-        self.image_threshold = AnomalyScoreThreshold().cpu()
-        self.pixel_threshold = AnomalyScoreThreshold().cpu()
+
+        threshold_config = kwargs.pop("threshold", dict())
+        self.image_threshold = MethodToThrehsoldMapping.get(threshold_config.method, AnomalyScoreThreshold)(
+            **threshold_config
+        ).cpu()
+        self.pixel_threshold = AnomalyScoreThreshold(**threshold_config).cpu()
 
         self.normalization_metrics: Metric
 
@@ -142,6 +152,8 @@ class AnomalyModule(pl.LightningModule, ABC):
           outputs: Batch of outputs from the validation step
         """
         if self.threshold_method == ThresholdMethod.ADAPTIVE:
+            self._compute_adaptive_threshold(outputs)
+        if self.threshold_method == ThresholdMethod.MEANVAR:
             self._compute_adaptive_threshold(outputs)
         self._collect_outputs(self.image_metrics, self.pixel_metrics, outputs)
         self._log_metrics()

--- a/src/anomalib/models/components/base/anomaly_module.py
+++ b/src/anomalib/models/components/base/anomaly_module.py
@@ -52,7 +52,7 @@ class AnomalyModule(pl.LightningModule, ABC):
 
         self.threshold_method: ThresholdMethod
 
-        threshold_config = kwargs.pop("threshold", dict())
+        threshold_config = kwargs.pop("threshold", {})
         self.image_threshold = MethodToThrehsoldMapping.get(threshold_config.method, AnomalyScoreThreshold)(
             **threshold_config
         ).cpu()

--- a/src/anomalib/models/padim/config.yaml
+++ b/src/anomalib/models/padim/config.yaml
@@ -15,7 +15,7 @@ dataset:
     eval: null
   test_split_mode: from_dir # options: [from_dir, synthetic]
   test_split_ratio: 0.2 # fraction of train images held out testing (usage depends on test_split_mode)
-  val_split_mode: same_as_test # options: [same_as_test, from_test, synthetic]
+  val_split_mode: same_as_test # options: [same_as_test, from_test, synthetic, same_as_train]
   val_split_ratio: 0.5 # fraction of train/test images held out for validation (usage depends on val_split_mode)
   tiling:
     apply: false
@@ -43,7 +43,9 @@ metrics:
     - F1Score
     - AUROC
   threshold:
-    method: adaptive #options: [adaptive, manual]
+    method: meanvar #options: [adaptive, manual, meanvar]
+    std_dev_ratio: 3
+    meanvar_mode: add
     manual_image: null
     manual_pixel: null
 

--- a/src/anomalib/models/padim/lightning_model.py
+++ b/src/anomalib/models/padim/lightning_model.py
@@ -42,8 +42,9 @@ class Padim(AnomalyModule):
         backbone: str,
         pre_trained: bool = True,
         n_features: int | None = None,
+        **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(**kwargs)
 
         self.layers = layers
         self.model: PadimModel = PadimModel(
@@ -126,6 +127,7 @@ class PadimLightning(Padim):
             backbone=hparams.model.backbone,
             pre_trained=hparams.model.pre_trained,
             n_features=hparams.model.n_features if "n_features" in hparams.model else None,
+            threshold=hparams.metrics.threshold,
         )
         self.hparams: DictConfig | ListConfig  # type: ignore
         self.save_hyperparameters(hparams)

--- a/src/anomalib/post_processing/post_process.py
+++ b/src/anomalib/post_processing/post_process.py
@@ -19,6 +19,7 @@ class ThresholdMethod(str, Enum):
 
     ADAPTIVE = "adaptive"
     MANUAL = "manual"
+    MEANVAR = "meanvar"
 
 
 def add_label(

--- a/src/anomalib/utils/callbacks/__init__.py
+++ b/src/anomalib/utils/callbacks/__init__.py
@@ -81,10 +81,19 @@ def get_callbacks(config: DictConfig | ListConfig) -> list[Callback]:
     pixel_threshold = (
         config.metrics.threshold.manual_pixel if "manual_pixel" in config.metrics.threshold.keys() else None
     )
+
+    std_dev_ratio = (
+        config.metrics.threshold.std_dev_ratio if "std_dev_ratio" in config.metrics.threshold.keys() else None
+    )
+
+    meanvar_mode = config.metrics.threshold.meanvar_mode if "meanvar_mode" in config.metrics.threshold.keys() else None
+
     post_processing_callback = PostProcessingConfigurationCallback(
         threshold_method=config.metrics.threshold.method,
         manual_image_threshold=image_threshold,
         manual_pixel_threshold=pixel_threshold,
+        std_dev_ratio=std_dev_ratio,
+        meanvar_mode=meanvar_mode,
     )
     callbacks.append(post_processing_callback)
 

--- a/src/anomalib/utils/callbacks/post_processing_configuration.py
+++ b/src/anomalib/utils/callbacks/post_processing_configuration.py
@@ -35,6 +35,8 @@ class PostProcessingConfigurationCallback(Callback):
         threshold_method: ThresholdMethod = ThresholdMethod.ADAPTIVE,
         manual_image_threshold: float | None = None,
         manual_pixel_threshold: float | None = None,
+        std_dev_ratio: float | None = None,
+        meanvar_mode: str | None = None,
     ) -> None:
         super().__init__()
         self.normalization_method = normalization_method
@@ -51,13 +53,23 @@ class PostProcessingConfigurationCallback(Callback):
             i is None for i in (manual_image_threshold, manual_pixel_threshold)
         ):
             raise ValueError(
-                "When `threshold_method` is set to `manual`, `manual_image_threshold` and `manual_pixel_threshold` "
+                "When `threshold.method` is set to `manual`, `manual_image_threshold` and `manual_pixel_threshold` "
                 "must be set."
+            )
+
+        if threshold_method == ThresholdMethod.MEANVAR and any(
+            i is not None for i in (manual_image_threshold, manual_pixel_threshold)
+        ):
+            raise ValueError(
+                "When ``threshold.method` is set to `meanvar`, `manual_image_threshold` or `manual_pixel_threshold` "
+                "must not be set."
             )
 
         self.threshold_method = threshold_method
         self.manual_image_threshold = manual_image_threshold
         self.manual_pixel_threshold = manual_pixel_threshold
+        self.std_dev_ratio = std_dev_ratio
+        self.meanvar_mode = meanvar_mode
 
     def setup(self, trainer: Trainer, pl_module: LightningModule, stage: str | None = None) -> None:
         """Setup post-processing configuration within Anomalib Model.
@@ -74,3 +86,14 @@ class PostProcessingConfigurationCallback(Callback):
             if pl_module.threshold_method == ThresholdMethod.MANUAL:
                 pl_module.image_threshold.value = torch.tensor(self.manual_image_threshold).cpu()
                 pl_module.pixel_threshold.value = torch.tensor(self.manual_pixel_threshold).cpu()
+            if pl_module.threshold_method == ThresholdMethod.MEANVAR:
+                image_threshold = pl_module.image_threshold
+                pixel_threshold = pl_module.pixel_threshold
+                image_threshold.std_dev_ratio = self.std_dev_ratio
+                image_threshold.meanvar_mode = self.meanvar_mode
+                image_threshold.std_dev_ratio = self.std_dev_ratio
+                image_threshold.meanvar_mode = self.meanvar_mode
+                pixel_threshold.std_dev_ratio = self.std_dev_ratio
+                pixel_threshold.meanvar_mode = self.meanvar_mode
+                pixel_threshold.std_dev_ratio = self.std_dev_ratio
+                pixel_threshold.meanvar_mode = self.meanvar_mode

--- a/src/anomalib/utils/cli/cli.py
+++ b/src/anomalib/utils/cli/cli.py
@@ -68,6 +68,8 @@ class AnomalibCLI(LightningCLI):
                 "post_processing.threshold_method": "adaptive",
                 "post_processing.manual_image_threshold": None,
                 "post_processing.manual_pixel_threshold": None,
+                "post_processing.meanvar_mode": None,
+                "post_processing.std_dev_ratio": None,
             }
         )
 

--- a/src/anomalib/utils/metrics/__init__.py
+++ b/src/anomalib/utils/metrics/__init__.py
@@ -13,7 +13,7 @@ import torchmetrics
 from omegaconf import DictConfig, ListConfig
 
 from .anomaly_score_distribution import AnomalyScoreDistribution
-from .anomaly_score_threshold import AnomalyScoreThreshold
+from .anomaly_score_threshold import AnomalyScoreMeanVarThreshold, AnomalyScoreThreshold
 from .aupr import AUPR
 from .aupro import AUPRO
 from .auroc import AUROC
@@ -22,7 +22,17 @@ from .min_max import MinMax
 from .optimal_f1 import OptimalF1
 from .pro import PRO
 
-__all__ = ["AUROC", "AUPR", "AUPRO", "OptimalF1", "AnomalyScoreThreshold", "AnomalyScoreDistribution", "MinMax", "PRO"]
+__all__ = [
+    "AUROC",
+    "AUPR",
+    "AUPRO",
+    "OptimalF1",
+    "AnomalyScoreThreshold",
+    "AnomalyScoreDistribution",
+    "MinMax",
+    "PRO",
+    "AnomalyScoreMeanVarThreshold",
+]
 
 
 def metric_collection_from_names(metric_names: list[str], prefix: str | None) -> AnomalibMetricCollection:

--- a/src/anomalib/utils/metrics/anomaly_score_threshold.py
+++ b/src/anomalib/utils/metrics/anomaly_score_threshold.py
@@ -81,8 +81,8 @@ class AnomalyScoreMeanVarThreshold(AnomalyScoreThreshold):
     MEANVAR_MODE = MeanVarianceMode.ADD
 
     def __init__(self, default_value: float = 0.5, **kwargs) -> None:
-        self.meanvar_mode = self.MEANVAR_MODE
-        self.std_dev_ratio = self.STD_DEV_RATIO
+        self.meanvar_mode = kwargs.get("meanvar_mode", self.MEANVAR_MODE)
+        self.std_dev_ratio = kwargs.get("std_dev_ratio", self.STD_DEV_RATIO)
         super().__init__(default_value=default_value, **kwargs)
 
     def compute(self) -> Tensor:

--- a/src/anomalib/utils/metrics/anomaly_score_threshold.py
+++ b/src/anomalib/utils/metrics/anomaly_score_threshold.py
@@ -81,8 +81,8 @@ class AnomalyScoreMeanVarThreshold(AnomalyScoreThreshold):
     MEANVAR_MODE = MeanVarianceMode.ADD
 
     def __init__(self, default_value: float = 0.5, **kwargs) -> None:
-        self.meanvar_mode: MeanVarianceMode
-        self.std_dev_ratio: float
+        self.meanvar_mode = self.MEANVAR_MODE
+        self.std_dev_ratio = self.STD_DEV_RATIO
         super().__init__(default_value=default_value, **kwargs)
 
     def compute(self) -> Tensor:

--- a/src/anomalib/utils/metrics/anomaly_score_threshold.py
+++ b/src/anomalib/utils/metrics/anomaly_score_threshold.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import warnings
+from enum import Enum
 
 import torch
 from torch import Tensor
@@ -50,7 +51,6 @@ class AnomalyScoreThreshold(PrecisionRecallCurve):
                 "to poor predictions. For a more reliable adaptive threshold computation, please add some anomalous "
                 "images to the validation set."
             )
-
         precision, recall, thresholds = super().compute()
         f1_score = (2 * precision * recall) / (precision + recall + 1e-10)
         if thresholds.dim() == 0:
@@ -59,4 +59,52 @@ class AnomalyScoreThreshold(PrecisionRecallCurve):
             self.value = thresholds
         else:
             self.value = thresholds[torch.argmax(f1_score)]
+        return self.value
+
+
+class MeanVarianceMode(str, Enum):
+    """Supported Mean Variance Combination Type"""
+
+    ADD = "add"
+    MINUS = "minus"
+
+
+class AnomalyScoreMeanVarThreshold(AnomalyScoreThreshold):
+    """Anomaly Score Threshold.
+
+    This class computes/stores the threshold that determines the anomalous label
+    given anomaly scores. The computation is based on the mean and variance.
+
+    """
+
+    STD_DEV_RATIO = 0.1
+    MEANVAR_MODE = MeanVarianceMode.ADD
+
+    def __init__(self, default_value: float = 0.5, **kwargs) -> None:
+        self.meanvar_mode: MeanVarianceMode
+        self.std_dev_ratio: float
+        super().__init__(default_value=default_value, **kwargs)
+
+    def compute(self) -> Tensor:
+        """Compute the threshold.
+
+        Compute the threshold based on the mean and variance of the predictions
+
+        Returns:
+            Value of threshold.
+        """
+
+        if not any(1 in batch for batch in self.target):
+            warnings.warn(
+                "The validation set does not contain any anomalous images. As a result, the adaptive threshold will "
+                "take the value of the highest anomaly score observed in the normal validation images, which may lead "
+                "to poor predictions. For a more reliable adaptive threshold computation, please add some anomalous "
+                "images to the validation set."
+            )
+        mean_pred = torch.mean(torch.cat(self.preds, dim=0))
+        std_pred = torch.std(torch.cat(self.preds, dim=0))
+        if self.meanvar_mode == MeanVarianceMode.MINUS:
+            self.value = mean_pred - self.std_dev_ratio * std_pred
+        else:
+            self.value = mean_pred + self.std_dev_ratio * std_pred
         return self.value

--- a/src/anomalib/utils/sweep/helpers/callbacks.py
+++ b/src/anomalib/utils/sweep/helpers/callbacks.py
@@ -14,6 +14,7 @@ from anomalib.utils.callbacks import (
     PostProcessingConfigurationCallback,
 )
 from anomalib.utils.callbacks.timer import TimerCallback
+from anomalib.utils.metrics import AnomalyScoreMeanVarThreshold
 
 
 def get_sweep_callbacks(config: DictConfig | ListConfig) -> list[Callback]:
@@ -39,6 +40,17 @@ def get_sweep_callbacks(config: DictConfig | ListConfig) -> list[Callback]:
             config.metrics.threshold.manual_pixel if "manual_pixel" in config.metrics.threshold.keys() else None
         )
         normalization_method = config.model.normalization_method
+        # This is for AnomalyScoreMeanVarThreshold
+        std_dev_ratio = (
+            config.metrics.threshold.std_dev_ratio
+            if "std_dev_ratio" in config.metrics.threshold.keys()
+            else AnomalyScoreMeanVarThreshold.DEFAULT_POSITIVE_RATE
+        )
+        meanvar_mode = (
+            config.metrics.threshold.meanvar_mode
+            if "meanvar_mode" in config.metrics.threshold.keys()
+            else AnomalyScoreMeanVarThreshold.MEANVAR_MODE
+        )
     # NOTE: This is for the new anomalib CLI.
     else:
         image_metrics = config.metrics.image_metrics if "image_metrics" in config.metrics else None
@@ -50,12 +62,26 @@ def get_sweep_callbacks(config: DictConfig | ListConfig) -> list[Callback]:
             config.post_processing.manual_pixel_threshold if "pixel_default" in config.post_processing.keys() else None
         )
         normalization_method = config.post_processing.normalization_method
+        # This is for AnomalyScoreMeanVarThreshold
+        std_dev_ratio = (
+            config.post_processing.std_dev_ratio
+            if "std_dev_ratio" in config.post_processing.keys()
+            else AnomalyScoreMeanVarThreshold.DEFAULT_POSITIVE_RATE
+        )
+        meanvar_mode = (
+            config.post_processing.meanvar_mode
+            if "meanvar_mode" in config.post_processing.keys()
+            else AnomalyScoreMeanVarThreshold.MEANVAR_MODE
+        )
 
     post_processing_configuration_callback = PostProcessingConfigurationCallback(
         normalization_method=normalization_method,
         manual_image_threshold=image_threshold,
         manual_pixel_threshold=pixel_threshold,
+        std_dev_ratio=std_dev_ratio,
+        meanvar_mode=meanvar_mode,
     )
+
     callbacks.append(post_processing_configuration_callback)
 
     metrics_configuration_callback = MetricsConfigurationCallback(

--- a/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
+++ b/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
@@ -35,8 +35,8 @@ def test_adaptive_threshold(labels, preds, target_threshold):
 @pytest.mark.parametrize(
     ["labels", "preds", "target_threshold"],
     [
-        (torch.Tensor([0, 0, 0, 1, 1]), torch.Tensor([2.3, 1.6, 2.6, 7.9, 3.3]), 3.7913),  # standard case
-        (torch.Tensor([1, 0, 0, 0]), torch.Tensor([4, 3, 2, 1]), 2.6291),  # 100% recall for all thresholds
+        (torch.Tensor([0, 0, 0, 1, 1]), torch.Tensor([2.3, 1.6, 2.6, 7.9, 3.3]), 3.7913),
+        (torch.Tensor([1, 0, 0, 0]), torch.Tensor([4.0, 3.0, 2.0, 1.0]), 2.6291),
     ],
 )
 def test_meanvar_threshold(labels, preds, target_threshold):
@@ -45,7 +45,7 @@ def test_meanvar_threshold(labels, preds, target_threshold):
     meanvar_threshold = AnomalyScoreMeanVarThreshold(default_value=0.5)
     meanvar_threshold.update(preds, labels)
     threshold_value = meanvar_threshold.compute()
-    assert threshold_value == target_threshold
+    assert round(threshold_value, 4) == target_threshold
 
 
 def test_manual_threshold():

--- a/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
+++ b/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
@@ -11,7 +11,7 @@ from pytorch_lightning import Trainer
 from anomalib.data import get_datamodule
 from anomalib.models import get_model
 from anomalib.utils.callbacks import get_callbacks
-from anomalib.utils.metrics import AnomalyScoreThreshold
+from anomalib.utils.metrics import AnomalyScoreThreshold, AnomalyScoreMeanVarThreshold
 from tests.helpers.config import get_test_configurable_parameters
 
 
@@ -29,6 +29,22 @@ def test_adaptive_threshold(labels, preds, target_threshold):
     adaptive_threshold.update(preds, labels)
     threshold_value = adaptive_threshold.compute()
 
+    assert threshold_value == target_threshold
+
+
+@pytest.mark.parametrize(
+    ["labels", "preds", "target_threshold"],
+    [
+        (torch.Tensor([0, 0, 0, 1, 1]), torch.Tensor([2.3, 1.6, 2.6, 7.9, 3.3]), 3.7913),  # standard case
+        (torch.Tensor([1, 0, 0, 0]), torch.Tensor([4, 3, 2, 1]), 2.6291),  # 100% recall for all thresholds
+    ],
+)
+def test_meanvar_threshold(labels, preds, target_threshold):
+    """Test if the adaptive threshold computation returns the desired value."""
+
+    meanvar_threshold = AnomalyScoreMeanVarThreshold(default_value=0.5)
+    meanvar_threshold.update(preds, labels)
+    threshold_value = meanvar_threshold.compute()
     assert threshold_value == target_threshold
 
 

--- a/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
+++ b/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
@@ -40,7 +40,7 @@ def test_adaptive_threshold(labels, preds, target_threshold):
     ],
 )
 def test_meanvar_threshold(labels, preds, target_threshold):
-    """Test if the adaptive threshold computation returns the desired value."""
+    """Test if the meanvar threshold computation returns the desired value."""
 
     meanvar_threshold = AnomalyScoreMeanVarThreshold(default_value=0.5)
     meanvar_threshold.update(preds, labels)

--- a/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
+++ b/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
@@ -44,7 +44,7 @@ def test_meanvar_threshold(labels, preds, target_threshold):
 
     meanvar_threshold = AnomalyScoreMeanVarThreshold(default_value=0.5)
     meanvar_threshold.update(preds, labels)
-    threshold_value = meanvar_threshold.compute()
+    threshold_value = meanvar_threshold.compute().item()
     assert round(threshold_value, 4) == target_threshold
 
 


### PR DESCRIPTION
# Description

- Provide a summary of the modification as well as the issue that has been resolved. List any dependencies that this modification necessitates.
1. Use train data as validation data during validation and collect all the predictions
2. Based on the predictions above, perform three sigma rule to determine the final threshold: `mean - 3 * standard_deviation` or` mean + 3 * standard_deviation`, +/- is determined by config. Currently, only the + scenario should be used, because currently this repo determines the result via checking whether the predictions is **larger** than the threshold.

- Fixes #1027

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
