### PR TITLE
🐞 Remove Upper Bound on `wandb` Dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ loggers = [
     "comet-ml>=3.31.7",
     "gradio>=4",
     "tensorboard",
-    "wandb>=0.12.17,<=0.15.9",
+    "wandb>=0.12.17",
     "mlflow >=1.0.0",
 ]
 notebooks = ["gitpython", "ipykernel", "ipywidgets", "notebook"]

--- a/tests/integration/model/test_models.py
+++ b/tests/integration/model/test_models.py
@@ -148,6 +148,11 @@ class TestAPI:
             # https://github.com/openvinotoolkit/anomalib/issues/1513
             pytest.skip(f"{model_name} fails to convert to OpenVINO")
 
+        # TODO(samet-akcay, ashwinvaidya17): Fix this test after fixing the issue
+        # https://github.com/openvinotoolkit/anomalib/issues/2047
+        if model_name == "cs_flow" and export_type == ExportType.OPENVINO:
+            pytest.skip(f"{model_name} is not supported for OpenVINO export")
+
         model, dataset, engine = self._get_objects(
             model_name=model_name,
             dataset_path=dataset_path,


### PR DESCRIPTION
## 📝 Description

This PR removes the upper bound constraint on the `wandb` dependency in our package. This change is necessary to resolve installation issues with Python 3.12, where the imp module has been removed.

Users attempting to install our package on Python 3.12 were encountering the following error:
```bash
ModuleNotFoundError: No module named 'imp'
```

This error occurs because older versions of `wandb` (and potentially other dependencies) were using the deprecated `imp` module, which has been removed in Python 3.12.

- 🛠️ Fixes #2279 

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
