### PR TITLE
Fix docs, config and folder support for tiled ensemble

### DIFF
--- a/docs/source/markdown/guides/how_to/pipelines/tiled_ensemble.md
+++ b/docs/source/markdown/guides/how_to/pipelines/tiled_ensemble.md
@@ -50,7 +50,7 @@ General settings at the top of the config file are used to set up the random `se
 
 ```{code-block} yaml
 seed: 42
-accelerator: "gpu"
+accelerator: "cuda"
 default_root_dir: "results"
 ```
 

--- a/src/anomalib/pipelines/tiled_ensemble/components/utils/ensemble_engine.py
+++ b/src/anomalib/pipelines/tiled_ensemble/components/utils/ensemble_engine.py
@@ -50,8 +50,12 @@ class TiledEnsembleEngine(Engine):
             Path: path to new workspace root dir
         """
         model_name = args["TrainModels"]["model"]["class_path"].split(".")[-1]
-        dataset_name = args["data"]["class_path"].split(".")[-1]
-        category = args["data"]["init_args"]["category"]
+        # get dataset name if present in init_args
+        dataset_name = args["data"]["init_args"].get("name", None)
+        if dataset_name is None:
+            # if not specified, take class name
+            dataset_name = args["data"]["class_path"].split(".")[-1]
+        category = args["data"]["init_args"].get("category", "")
         root_dir = Path(args["default_root_dir"]) / model_name / dataset_name / category
         return create_versioned_dir(root_dir) if versioned_dir else root_dir / "latest"
 

--- a/src/anomalib/pipelines/tiled_ensemble/train_pipeline.py
+++ b/src/anomalib/pipelines/tiled_ensemble/train_pipeline.py
@@ -92,9 +92,12 @@ class TrainTiledEnsemble(Pipeline):
                 ),
             )
 
-        if data_args["init_args"]["val_split_mode"] == ValSplitMode.NONE:
+        val_split_mode = data_args["init_args"].get("val_split_mode", None)
+        if val_split_mode == ValSplitMode.NONE:
             logger.warning("No validation set provided, skipping statistics calculation.")
             return runners
+        if val_split_mode is None:
+            logger.warning("Validation split mode not set in data config, dataset specific default will be used.")
 
         # 2. predict using validation data
         if accelerator == "cuda":

--- a/tools/tiled_ensemble/ens_config.yaml
+++ b/tools/tiled_ensemble/ens_config.yaml
@@ -1,5 +1,5 @@
 seed: 42
-accelerator: "gpu"
+accelerator: "cuda"
 default_root_dir: "results"
 
 tiling:


### PR DESCRIPTION
## 📝 Description

- This PR fixes some bugs within the tiled ensemble code: 1. replaces accelerator value "gpu" in config with "cuda" and also fixes the docs to reflect this correctly. 2. Fixes project root dir naming code to support Folder dataset. 3. Fixes val and test split reading from config file, to enable absence of val/test_split_mode field in config.
- 🛠️ Fixes #2409 

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [x] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
