### PR TITLE
🔨Update imports causing import warnings

### DIFF
--- a/docs/source/markdown/guides/how_to/models/post_processor.md
+++ b/docs/source/markdown/guides/how_to/models/post_processor.md
@@ -144,7 +144,7 @@ One key advantage of Anomalib's post-processor design is that it becomes part of
 ```python
 from anomalib.models import Patchcore
 from anomalib.post_processing import PostProcessor
-from openvino.runtime import Core
+from openvino import Core
 import numpy as np
 
 # Training: Post-processor is part of the model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,7 @@ core = [
     "lightning>=2.2",
     "torch>=2",
     "torchmetrics>=1.3.2",
-    # NOTE: open-clip-torch throws the following error on v2.26.1
-    #   torch.onnx.errors.UnsupportedOperatorError: Exporting the operator
-    #   'aten::_native_multi_head_attention' to ONNX opset version 14 is not supported
-    "open-clip-torch>=2.23.0,<2.26.1",
+    "open-clip-torch>=2.32.0",
     "fvcore",
 ]
 openvino = ["openvino>=2024.0", "nncf>=2.10.0", "onnx>=1.16.0"]

--- a/src/anomalib/deploy/inferencers/openvino_inferencer.py
+++ b/src/anomalib/deploy/inferencers/openvino_inferencer.py
@@ -56,7 +56,7 @@ from typing import Any
 import numpy as np
 import torch
 from lightning_utilities.core.imports import module_available
-from openvino.runtime.utils.data_helpers.wrappers import OVDict
+from openvino.utils.data_helpers.wrappers import OVDict
 from PIL.Image import Image as PILImage
 
 from anomalib.data import NumpyImageBatch

--- a/src/anomalib/models/components/base/export_mixin.py
+++ b/src/anomalib/models/components/base/export_mixin.py
@@ -159,6 +159,7 @@ class ExportMixin:
             dynamic_axes=dynamic_axes,
             input_names=["input"],
             output_names=output_names,
+            dynamo=True,
         )
 
         return onnx_path


### PR DESCRIPTION
## 📝 Description

openvino.runtime is deprecated and keeps throwing warnings making the cli look "ugly". 
There is also a deprecating warning from timm.model.layers used by an older version of open-clip. In this pr, open-clip is updated as well to prevent timm.model.layer import warnings. 

- 🛠️ Fixes #2694


## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/open-edge-platform/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
