### PR TITLE
Fix SuperSimpleNet pretrained weights.

### DIFF
--- a/src/anomalib/models/image/supersimplenet/README.md
+++ b/src/anomalib/models/image/supersimplenet/README.md
@@ -28,6 +28,12 @@ This implementation supports both unsupervised and supervised setting, but Anoma
 
 `anomalib train --model SuperSimpleNet --data MVTecAD --data.category <category>`
 
+IMPORTANT!
+
+The model is verified to work with WideResNet50 using torchvision V1 weights.
+It should work with most ResNets and WideResNets, but make sure you use V1 weights if you use default noise std value.
+Correct weight name ends with ".tv\_[...]", not "tv2" (e.g. "wide_resnet50_2.tv_in1k").
+
 > It is recommended to train the model for 300 epochs with batch size of 32 to achieve stable training with random anomaly generation. Training with lower parameter values will still work, but might not yield the optimal results.
 >
 > For supervised learning, refer to the [official code](https://github.com/blaz-r/SuperSimpleNet).

--- a/src/anomalib/models/image/supersimplenet/README.md
+++ b/src/anomalib/models/image/supersimplenet/README.md
@@ -33,7 +33,7 @@ This implementation supports both unsupervised and supervised setting, but Anoma
 > The model is verified to work with WideResNet50 using torchvision V1 weights.
 > It should work with most ResNets and WideResNets, but make sure you use V1 weights if you use default noise std value.
 > Correct weight name ends with ".tv\_[...]", not "tv2" (e.g. "wide_resnet50_2.tv_in1k").
-
+>
 > It is recommended to train the model for 300 epochs with batch size of 32 to achieve stable training with random anomaly generation. Training with lower parameter values will still work, but might not yield the optimal results.
 >
 > For supervised learning, refer to the [official code](https://github.com/blaz-r/SuperSimpleNet).

--- a/src/anomalib/models/image/supersimplenet/README.md
+++ b/src/anomalib/models/image/supersimplenet/README.md
@@ -28,11 +28,11 @@ This implementation supports both unsupervised and supervised setting, but Anoma
 
 `anomalib train --model SuperSimpleNet --data MVTecAD --data.category <category>`
 
-IMPORTANT!
-
-The model is verified to work with WideResNet50 using torchvision V1 weights.
-It should work with most ResNets and WideResNets, but make sure you use V1 weights if you use default noise std value.
-Correct weight name ends with ".tv\_[...]", not "tv2" (e.g. "wide_resnet50_2.tv_in1k").
+> IMPORTANT!
+>
+> The model is verified to work with WideResNet50 using torchvision V1 weights.
+> It should work with most ResNets and WideResNets, but make sure you use V1 weights if you use default noise std value.
+> Correct weight name ends with ".tv\_[...]", not "tv2" (e.g. "wide_resnet50_2.tv_in1k").
 
 > It is recommended to train the model for 300 epochs with batch size of 32 to achieve stable training with random anomaly generation. Training with lower parameter values will still work, but might not yield the optimal results.
 >

--- a/src/anomalib/models/image/supersimplenet/lightning_model.py
+++ b/src/anomalib/models/image/supersimplenet/lightning_model.py
@@ -61,7 +61,7 @@ class Supersimplenet(AnomalibModule):
 
     Args:
         perlin_threshold (float): threshold value for Perlin noise thresholding during anomaly generation.
-        backbone (str): backbone name
+        backbone (str): backbone name. IMPORTANT! use only backbones with torchvision V1 weights ending on ".tv".
         layers (list[str]): backbone layers utilised
         supervised (bool): whether the model will be trained in supervised mode. False by default (unsupervised).
         pre_processor (PreProcessor | bool, optional): Pre-processor instance or
@@ -77,7 +77,7 @@ class Supersimplenet(AnomalibModule):
     def __init__(
         self,
         perlin_threshold: float = 0.2,
-        backbone: str = "wide_resnet50_2",
+        backbone: str = "wide_resnet50_2.tv_in1k",  # IMPORTANT: use .tv weights, not tv2
         layers: list[str] = ["layer2", "layer3"],  # noqa: B006
         supervised: bool = False,
         pre_processor: PreProcessor | bool = True,

--- a/src/anomalib/models/image/supersimplenet/torch_model.py
+++ b/src/anomalib/models/image/supersimplenet/torch_model.py
@@ -33,7 +33,7 @@ class SupersimplenetModel(nn.Module):
 
     Args:
         perlin_threshold (float): threshold value for Perlin noise thresholding during anomaly generation.
-        backbone (str): backbone name
+        backbone (str): backbone name. IMPORTANT! use only backbones with torchvision V1 weights ending on ".tv".
         layers (list[str]): backbone layers utilised
         stop_grad (bool): whether to stop gradient from class. to seg. head.
     """
@@ -41,7 +41,7 @@ class SupersimplenetModel(nn.Module):
     def __init__(
         self,
         perlin_threshold: float = 0.2,
-        backbone: str = "wide_resnet50_2",
+        backbone: str = "wide_resnet50_2.tv_in1k",  # IMPORTANT: use .tv weights, not tv2
         layers: list[str] = ["layer2", "layer3"],  # noqa: B006
         stop_grad: bool = True,
     ) -> None:


### PR DESCRIPTION
## 📝 Description

- This PR adds a fix for SuperSimpleNet, where incorrect pretrained weights were used.
- 🛠️ Fixes #2688 

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/open-edge-platform/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
