### PR TITLE
🔒 Security Fix: Mitigate Remote Code Execution Risk in `torch.load`

### DIFF
--- a/src/anomalib/callbacks/model_loader.py
+++ b/src/anomalib/callbacks/model_loader.py
@@ -81,4 +81,6 @@ class LoadModelCallback(Callback):
         del trainer, stage  # These variables are not used.
 
         logger.info("Loading the model from %s", self.weights_path)
-        pl_module.load_state_dict(torch.load(self.weights_path, map_location=pl_module.device)["state_dict"])
+        pl_module.load_state_dict(
+            torch.load(self.weights_path, map_location=pl_module.device, weights_only=True)["state_dict"],
+        )

--- a/src/anomalib/models/image/dsr/torch_model.py
+++ b/src/anomalib/models/image/dsr/torch_model.py
@@ -906,7 +906,7 @@ class VectorQuantizer(nn.Module):
 
         # necessary to correctly load the checkpoint file
         self.register_buffer("_ema_cluster_size", torch.zeros(num_embeddings))
-        self._ema_w = nn.Parameter(torch.Tensor(num_embeddings, self._embedding_dim))
+        self._ema_w = nn.Parameter(torch.zeros(num_embeddings, self._embedding_dim))
         self._ema_w.data.normal_()
 
     @property

--- a/src/anomalib/models/image/dsr/torch_model.py
+++ b/src/anomalib/models/image/dsr/torch_model.py
@@ -128,7 +128,7 @@ class DsrModel(nn.Module):
             device (torch.device | str | None, optional): Device to load weights
                 to. Defaults to ``None``.
         """
-        self.discrete_latent_model.load_state_dict(torch.load(ckpt, map_location=device))
+        self.discrete_latent_model.load_state_dict(torch.load(ckpt, map_location=device, weights_only=True))
 
     def forward(
         self,

--- a/src/anomalib/models/image/efficient_ad/lightning_model.py
+++ b/src/anomalib/models/image/efficient_ad/lightning_model.py
@@ -167,7 +167,9 @@ class EfficientAd(AnomalibModule):
             pretrained_models_dir / "efficientad_pretrained_weights" / f"pretrained_teacher_{model_size_str}.pth"
         )
         logger.info(f"Load pretrained teacher model from {teacher_path}")
-        self.model.teacher.load_state_dict(torch.load(teacher_path, map_location=torch.device(self.device)))
+        self.model.teacher.load_state_dict(
+            torch.load(teacher_path, map_location=torch.device(self.device), weights_only=True),
+        )
 
     def prepare_imagenette_data(self, image_size: tuple[int, int] | torch.Size) -> None:
         """Prepare ImageNette dataset transformations.

--- a/src/anomalib/models/video/ai_vad/clip/clip.py
+++ b/src/anomalib/models/video/ai_vad/clip/clip.py
@@ -164,7 +164,7 @@ def load(
                 msg = f"File {model_path} is not a JIT archive. Loading as a state dict instead"
                 logger.warn(msg)
                 jit = False
-            state_dict = torch.load(opened_file, map_location="cpu", weights_only=True)
+            state_dict = torch.load(opened_file, map_location="cpu")
 
     if not jit:
         model = build_model(state_dict or model.state_dict()).to(device)

--- a/src/anomalib/models/video/ai_vad/clip/clip.py
+++ b/src/anomalib/models/video/ai_vad/clip/clip.py
@@ -164,7 +164,7 @@ def load(
                 msg = f"File {model_path} is not a JIT archive. Loading as a state dict instead"
                 logger.warn(msg)
                 jit = False
-            state_dict = torch.load(opened_file, map_location="cpu")
+            state_dict = torch.load(opened_file, map_location="cpu", weights_only=True)
 
     if not jit:
         model = build_model(state_dict or model.state_dict()).to(device)

--- a/src/anomalib/utils/path.py
+++ b/src/anomalib/utils/path.py
@@ -168,6 +168,29 @@ def convert_to_snake_case(s: str) -> str:
     return re.sub(r"__+", "_", s)
 
 
+def convert_snake_to_pascal_case(snake_case: str) -> str:
+    """Convert snake_case string to PascalCase.
+
+    This function takes a string in snake_case format (words separated by underscores)
+    and converts it to PascalCase format (each word capitalized and concatenated).
+
+    Args:
+        snake_case (str): Input string in snake_case format (e.g. ``"efficient_ad"``)
+
+    Returns:
+        str: Output string in PascalCase format (e.g. ``"EfficientAd"``)
+
+    Examples:
+        >>> convert_snake_to_pascal_case("efficient_ad")
+        'EfficientAd'
+        >>> convert_snake_to_pascal_case("patchcore")
+        'Patchcore'
+        >>> convert_snake_to_pascal_case("reverse_distillation")
+        'ReverseDistillation'
+    """
+    return "".join(word.capitalize() for word in snake_case.split("_"))
+
+
 def convert_to_title_case(text: str) -> str:
     """Convert text to title case, handling various text formats.
 

--- a/tests/integration/model/test_models.py
+++ b/tests/integration/model/test_models.py
@@ -17,12 +17,12 @@ import pytest
 from anomalib.data import AnomalibDataModule, MVTecAD
 from anomalib.deploy import ExportType
 from anomalib.engine import Engine
-from anomalib.models import AnomalibModule, get_available_models, get_model
+from anomalib.models import AnomalibModule, get_model, list_models
 
 
 def models() -> set[str]:
     """Return all available models."""
-    return get_available_models()
+    return list_models()
 
 
 def export_types() -> list[ExportType]:

--- a/tests/integration/tools/test_gradio_entrypoint.py
+++ b/tests/integration/tools/test_gradio_entrypoint.py
@@ -38,8 +38,12 @@ class TestGradioInferenceEntrypoint:
     def test_torch_inference(
         get_functions: tuple[Callable, Callable],
         ckpt_path: Callable[[str], Path],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test gradio_inference.py."""
+        # Set TRUST_REMOTE_CODE environment variable for the test
+        monkeypatch.setenv("TRUST_REMOTE_CODE", "1")
+
         _ckpt_path = ckpt_path("Padim")
         parser, inferencer = get_functions
         model = Padim.load_from_checkpoint(_ckpt_path)

--- a/tests/integration/tools/test_torch_entrypoint.py
+++ b/tests/integration/tools/test_torch_entrypoint.py
@@ -35,8 +35,12 @@ class TestTorchInferenceEntrypoint:
         project_path: Path,
         ckpt_path: Callable[[str], Path],
         get_dummy_inference_image: str,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test torch_inference.py."""
+        # Set TRUST_REMOTE_CODE environment variable for the test
+        monkeypatch.setenv("TRUST_REMOTE_CODE", "1")
+
         _ckpt_path = ckpt_path("Padim")
         get_parser, infer = get_functions
         model = Padim.load_from_checkpoint(_ckpt_path)

--- a/tests/unit/deploy/test_inferencer.py
+++ b/tests/unit/deploy/test_inferencer.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Iterable
 from pathlib import Path
 
 import numpy as np
+import pytest
 import torch
 
 from anomalib.deploy import ExportType, OpenVINOInferencer, TorchInferencer
@@ -46,16 +47,18 @@ class _MockImageLoader:
             yield self.image
 
 
-def test_torch_inference(ckpt_path: Callable[[str], Path]) -> None:
+def test_torch_inference(ckpt_path: Callable[[str], Path], monkeypatch: pytest.MonkeyPatch) -> None:
     """Tests Torch inference.
 
     Model is not trained as this checks that the inferencers are working.
 
     Args:
-        task (TaskType): Task type
         ckpt_path: Callable[[str], Path]: Path to trained PADIM model checkpoint.
-        dataset_path (Path): Path to dummy dataset.
+        monkeypatch: pytest fixture for patching environment variables.
     """
+    # Set TRUST_REMOTE_CODE environment variable for the test
+    monkeypatch.setenv("TRUST_REMOTE_CODE", "1")
+
     model = Padim()
     engine = Engine()
     export_root = ckpt_path("Padim").parent.parent


### PR DESCRIPTION
# Security Fix: Mitigate Remote Code Execution Risk in `torch.load`

## 📝 Description
**Issue:**

This PR addresses a critical security vulnerability related to the usage of `torch.load` within the `TorchInferencer`. The `torch.load` function, by default, uses Python's `pickle` module, which can lead to arbitrary code execution if a malicious model file (`.pt` or `.pth`) is loaded. An attacker could craft a model file that, when loaded, executes arbitrary code on the user's system.

This issue was identified by static code analyzers and is a known risk associated with unpickling data from untrusted sources. While PyTorch's `weights_only=True` parameter offers some mitigation, it doesn't fully protect against all potential attack vectors, such as path traversal for arbitrary file overwrite, as highlighted in recent research.

**Solution:**

To mitigate this risk, we have implemented the following changes inspired by best practices seen in other major libraries like Hugging Face Transformers:

1.  **Default to Safe Loading:** `torch.load` is now called with `weights_only=True` by default. This restricts unpickling to only tensors, storages, and primitive types, significantly reducing the risk of arbitrary code execution for most common model checkpoints.

2.  **Explicit Opt-In for Unsafe Loading:** We have introduced an environment variable, `TRUST_REMOTE_CODE`.
    *   If this environment variable is set to `"1"` or `"true"` (case-insensitive), the system will revert to the original behavior, allowing `torch.load` to use the full `pickle` module. This is necessary for loading older model checkpoints or models that contain more than just weights (e.g., entire model architectures, custom code).
    *   **A prominent warning will be logged** when `TRUST_REMOTE_CODE` is enabled, alerting the user to the potential security risks.

3.  **Clear Error Handling:**
    *   If `weights_only=True` loading fails (e.g., because the checkpoint is an older format or contains arbitrary Python objects), and `TRUST_REMOTE_CODE` is *not* set, a `ValueError` is raised.
    *   This error message clearly explains that loading the model requires unsafe unpickling, highlights the security risks, and instructs the user to set `TRUST_REMOTE_CODE=True` only if they explicitly trust the source of the model checkpoint.
    *   The original `RuntimeError` from `torch.load` is chained to this `ValueError` for full debugging context.

4.  **Improved Logging:** The module now uses a named logger (`logging.getLogger(__name__)`) for better log management and control by applications using `anomalib`.

**Rationale:**

This approach aims to:
*   **Prioritize Security by Default:** Protect users from accidental remote code execution by defaulting to the safer `weights_only=True` loading mechanism.
*   **Maintain Usability:** Provide a clear and explicit mechanism (`TRUST_REMOTE_CODE`) for users who understand the risks and need to load older or more complex model checkpoints.
*   **Align with Industry Best Practices:** Adopt a similar explicit consent model used by other popular machine learning libraries.
*   **Inform Users:** Ensure users are aware of the risks and the necessary steps to take when dealing with potentially unsafe model files.

**Impact on Users:**

*   **Safer by Default:** Loading most standard model checkpoints will now be safer.
*   **Action Required for Some Models:** Users attempting to load older model files or checkpoints that are not compatible with `weights_only=True` will encounter a `ValueError`. To load these models, they **must** set the environment variable `TRUST_REMOTE_CODE=True`.
    ```bash
    export TRUST_REMOTE_CODE=True
    ```
    Or, if running Python directly:
    ```python
    import os
    os.environ["TRUST_REMOTE_CODE"] = "True"
    # ... then import/use anomalib
    ```
*   **Increased Awareness:** Users will be explicitly warned when enabling unsafe model loading.

**How to Test:**

1.  **Safe Model:** Attempt to load a model checkpoint known to be compatible with `weights_only=True` (e.g., a simple state dict). This should succeed without setting `TRUST_REMOTE_CODE`.
2.  **Unsafe Model (Simulated):**
    *   Attempt to load a model checkpoint that requires full pickling (e.g., an older format, or one intentionally saved with `pickle_module=pickle`).
    *   **Without `TRUST_REMOTE_CODE` set:** Verify that a `ValueError` is raised with the correct instructional message.
    *   **With `TRUST_REMOTE_CODE=True` set:** Verify that the model loads successfully, and a warning is logged about unsafe loading.

**Security Considerations:**

Users should be strongly advised to only set `TRUST_REMOTE_CODE=True` when they have verified the integrity and source of the model checkpoint and fully understand the potential risks of arbitrary code execution.

This change enhances the security posture of `anomalib` when handling PyTorch model files.

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔒 Security update
