### PR TITLE
fix(export): enhance model export with flexible `kwargs` support for `ONNX` and `OpenVINO`

### DIFF
--- a/src/anomalib/cli/cli.py
+++ b/src/anomalib/cli/cli.py
@@ -256,7 +256,7 @@ class AnomalibCLI:
         added = parser.add_method_arguments(
             Engine,
             "export",
-            skip={"ov_args", "model", "datamodule"},
+            skip={"ov_kwargs", "model", "datamodule"},
         )
         self.subcommand_method_arguments["export"] = added
         add_openvino_export_arguments(parser)
@@ -304,6 +304,9 @@ class AnomalibCLI:
             self.config_init = self.parser.instantiate_classes(self.config)
             self.datamodule = self._get(self.config_init, "data")
             if isinstance(self.datamodule, Dataset):
+                # Let PyTorch handle pin_memory automatically
+                # This ensures optimal behavior for both CPU and GPU users
+                # nosemgrep: trailofbits.python.automatic-memory-pinning.automatic-memory-pinning  # noqa: ERA001
                 self.datamodule = DataLoader(self.datamodule, collate_fn=self.datamodule.collate_fn)
             self.model = self._get(self.config_init, "model")
             self._configure_optimizers_method_to_model()

--- a/src/anomalib/cli/utils/openvino.py
+++ b/src/anomalib/cli/utils/openvino.py
@@ -24,7 +24,7 @@ else:
 def add_openvino_export_arguments(parser: ArgumentParser) -> None:
     """Add OpenVINO Model Optimizer arguments to the parser.
 
-    This function adds OpenVINO-specific export arguments to the parser under the `ov_args` prefix.
+    This function adds OpenVINO-specific export arguments to the parser under the `ov_kwargs` prefix.
     If OpenVINO is not installed, it logs an informational message and skips adding the arguments.
 
     The function adds Model Optimizer arguments like data_type, mean_values, etc. as optional
@@ -43,8 +43,8 @@ def add_openvino_export_arguments(parser: ArgumentParser) -> None:
 
         The parser will now accept OpenVINO arguments like:
 
-        >>> # parser.parse_args(['--ov_args.data_type', 'FP16'])
-        >>> # parser.parse_args(['--ov_args.mean_values', '[123.675,116.28,103.53]'])
+        >>> # parser.parse_args(['--ov_kwargs.data_type', 'FP16'])
+        >>> # parser.parse_args(['--ov_kwargs.mean_values', '[123.675,116.28,103.53]'])
 
     Notes:
         - Requires OpenVINO to be installed to add the arguments
@@ -52,7 +52,7 @@ def add_openvino_export_arguments(parser: ArgumentParser) -> None:
             - help
             - input_model
             - output_dir
-        - Arguments are added under the 'ov_args' prefix for namespacing
+        - Arguments are added under the 'ov_kwargs' prefix for namespacing
         - All OpenVINO arguments are made optional
 
     See Also:
@@ -66,6 +66,6 @@ def add_openvino_export_arguments(parser: ArgumentParser) -> None:
         for arg in ov_parser._actions:  # noqa: SLF001
             if arg.dest in {"help", "input_model", "output_dir"}:
                 continue
-            group.add_argument(f"--ov_args.{arg.dest}", type=arg.type, default=arg.default, help=arg.help)
+            group.add_argument(f"--ov_kwargs.{arg.dest}", type=arg.type, default=arg.default, help=arg.help)
     else:
         logger.info("OpenVINO is possibly not installed in the environment. Skipping adding it to parser.")

--- a/src/anomalib/engine/engine.py
+++ b/src/anomalib/engine/engine.py
@@ -648,9 +648,13 @@ class Engine:
             msg = f"Unknown type for dataloaders {type(dataloaders)}"
             raise TypeError(msg)
         if dataset is not None:
+            # Let PyTorch handle pin_memory automatically
+            # This ensures optimal behavior for both CPU and GPU users
+            # nosemgrep: trailofbits.python.automatic-memory-pinning.automatic-memory-pinning  # noqa: ERA001
             dataloaders.append(DataLoader(dataset, collate_fn=dataset.collate_fn))
         if data_path is not None:
             dataset = PredictDataset(data_path)
+            # nosemgrep: trailofbits.python.automatic-memory-pinning.automatic-memory-pinning  # noqa: ERA001
             dataloaders.append(DataLoader(dataset, collate_fn=dataset.collate_fn))
         dataloaders = dataloaders or None
 
@@ -733,7 +737,9 @@ class Engine:
         compression_type: CompressionType | None = None,
         datamodule: AnomalibDataModule | None = None,
         metric: Metric | str | None = None,
-        ov_args: dict[str, Any] | None = None,
+        ov_args: dict[str, Any] | None = None,  # deprecated
+        ov_kwargs: dict[str, Any] | None = None,
+        onnx_kwargs: dict[str, Any] | None = None,
         ckpt_path: str | Path | None = None,
     ) -> Path | None:
         r"""Export the model in PyTorch, ONNX or OpenVINO format.
@@ -746,7 +752,8 @@ class Engine:
             model_file_name (str = "model"): Name of the exported model file. If it is not set, the model is
                 is called "model". Defaults to "model".
             input_size (tuple[int, int] | None, optional): A statis input shape for the model, which is exported to ONNX
-                and OpenVINO format. Defaults to None.
+                and OpenVINO format.
+                Defaults to ``None.
             compression_type (CompressionType | None, optional): Compression type for OpenVINO exporting only.
                 Defaults to ``None``.
             datamodule (AnomalibDataModule | None, optional): Lightning datamodule.
@@ -757,8 +764,15 @@ class Engine:
                 Must be provided if ``CompressionType.INT8_ACQ`` is selected and must return higher value for better
                 performance of the model (OpenVINO export only).
                 Defaults to ``None``.
-            ov_args (dict[str, Any] | None, optional): This is optional and used only for OpenVINO's model optimizer.
+            ov_args (dict[str, Any] | None, optional): Deprecated. Use ov_kwargs instead.
+                This is optional and used only for OpenVINO's model optimizer.
                 Defaults to None.
+            ov_kwargs (dict[str, Any] | None, optional): This is optional and used only for OpenVINO's model optimizer.
+                Defaults to None.
+            onnx_kwargs (dict[str, Any] | None, optional): This is optional and used only for ONNX export options.
+                Passed to model.to_onnx or model.to_openvino.
+                See https://pytorch.org/docs/stable/onnx.html#torch.onnx.export for details.
+                Defaults to ``None``.
             ckpt_path (str | Path | None): Checkpoint path. If provided, the model will be loaded from this path.
 
         Returns:
@@ -788,6 +802,24 @@ class Engine:
                 --input_size "[256,256]" --compression_type INT8_PTQ --data MVTec
                 ```
         """
+        import warnings
+
+        if ov_args is not None:
+            warnings.warn(
+                "The 'ov_args' parameter is deprecated and will be removed in a future version. "
+                "Please use 'ov_kwargs' instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if ov_kwargs is not None:
+                warnings.warn(
+                    "Both 'ov_args' and 'ov_kwargs' were provided. 'ov_kwargs' will be used.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                ov_kwargs = ov_args
+
         export_type = ExportType(export_type)
         self._setup_trainer(model)
         if ckpt_path:
@@ -808,6 +840,7 @@ class Engine:
                 export_root=export_root,
                 model_file_name=model_file_name,
                 input_size=input_size,
+                **(onnx_kwargs or {}),
             )
         elif export_type == ExportType.OPENVINO:
             exported_model_path = model.to_openvino(
@@ -817,7 +850,8 @@ class Engine:
                 compression_type=compression_type,
                 datamodule=datamodule,
                 metric=metric,
-                ov_args=ov_args,
+                ov_kwargs=ov_kwargs,
+                onnx_kwargs=onnx_kwargs,
             )
         else:
             logging.error(f"Export type {export_type} is not supported yet.")

--- a/tests/integration/tools/test_gradio_entrypoint.py
+++ b/tests/integration/tools/test_gradio_entrypoint.py
@@ -74,7 +74,7 @@ class TestGradioInferenceEntrypoint:
         # export OpenVINO model
         model.to_openvino(
             export_root=_ckpt_path.parent.parent.parent,
-            ov_args={},
+            ov_kwargs={},
             task=TaskType.SEGMENTATION,
         )
 

--- a/tests/integration/tools/test_openvino_entrypoint.py
+++ b/tests/integration/tools/test_openvino_entrypoint.py
@@ -44,7 +44,7 @@ class TestOpenVINOInferenceEntrypoint:
         # export OpenVINO model
         model.to_openvino(
             export_root=_ckpt_path.parent.parent.parent,
-            ov_args={},
+            ov_kwargs={},
             task=TaskType.SEGMENTATION,
         )
 


### PR DESCRIPTION
## 📝 Description

- Enhanced the model export functionality in `ExportMixin` to provide more flexible configuration options for both ONNX and OpenVINO exports
- Added support for additional keyword arguments in both export methods
- Renamed `ov_args` to `ov_kwargs` for consistency in argument naming
- 🛠️ Fixes https://github.com/open-edge-platform/anomalib/issues/2415 https://github.com/open-edge-platform/anomalib/issues/2591

## ✨ Changes

Select what type of change your PR is:

- [x] 🔨 Refactor (non-breaking change which refactors the code base)
- [x] 🚀 New feature (non-breaking change which adds functionality)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [x] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/open-edge-platform/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [x] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

### Detailed Changes

1. Enhanced `to_onnx` method:
   - Added support for additional keyword arguments via `**kwargs`
   - Improved documentation with examples of common ONNX export options
   - Made the code more explicit by using keyword arguments for `torch.onnx.export`

2. Enhanced `to_openvino` method:
   - Added `onnx_kwargs` parameter to customize ONNX conversion
   - Renamed `ov_args` to `ov_kwargs` for consistency
   - Added comprehensive documentation for both parameters
   - Updated examples to demonstrate usage of new parameters

3. Code Quality Improvements:
   - Simplified argument handling using `kwargs.pop()` with defaults
   - Improved type hints and documentation
   - Made the code more maintainable and user-friendly

### Example Usage

```python
# Export to ONNX with custom options
model.to_onnx(
    "./exports",
    input_size=(224, 224),
    opset_version=12,
    do_constant_folding=True,
    verify=True
)

# Export to OpenVINO with custom options
model.to_openvino(
    "./exports",
    compression_type=CompressionType.INT8_PTQ,
    datamodule=datamodule,
    ov_kwargs={"input_shape": [1, 3, 224, 224]},
    onnx_kwargs={"opset_version": 12, "do_constant_folding": True}
)
```

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).