### PR TITLE
🐞fix(data): Fixed bug where MVTecLOCO GT Masks were not loaded correctly

### DIFF
--- a/src/anomalib/data/utils/image.py
+++ b/src/anomalib/data/utils/image.py
@@ -340,7 +340,7 @@ def read_mask(path: str | Path, as_tensor: bool = False) -> torch.Tensor | np.nd
         <class 'torch.Tensor'>
     """
     image = Image.open(path).convert("L")
-    return Mask(to_image(image).squeeze() / 255, dtype=torch.uint8) if as_tensor else np.array(image)
+    return Mask(to_image(image).squeeze() > 0, dtype=torch.uint8) if as_tensor else np.array(image)
 
 
 def read_depth_image(path: str | Path) -> np.ndarray:

--- a/tests/unit/data/utils/test_image.py
+++ b/tests/unit/data/utils/test_image.py
@@ -6,8 +6,9 @@
 from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 
-from anomalib.data.utils.image import get_image_filenames
+from anomalib.data.utils.image import Image, get_image_filenames, np, read_mask, torch
 
 
 class TestGetImageFilenames:
@@ -46,3 +47,41 @@ class TestGetImageFilenames:
         filename = dataset_path / "avenue/ground_truth_demo/testing_label_mask/1_label.mat"
         with pytest.raises(ValueError, match=r"``filename`` is not an image file*"):
             get_image_filenames(filename)
+
+
+class TestReadMask:
+    """Tests for ``read_mask`` function."""
+
+    @staticmethod
+    def test_mask_conversion_as_numpy(mocker: MockerFixture) -> None:
+        """Test that the function correctly converts the image to a numpy array."""
+        # Sample image: [[0, 236], [255, 0]]
+        mocker.patch(
+            "anomalib.data.utils.image.Image.open",
+            return_value=Image.fromarray(np.array([[0, 236], [255, 0]], dtype=np.uint8)),
+        )
+
+        # Mocks are setup, call function to test!
+        result = read_mask("dummy_path.png", as_tensor=False)
+
+        assert isinstance(result, np.ndarray)
+        np.testing.assert_array_equal(result, np.array([[0, 236], [255, 0]]))
+
+    @staticmethod
+    def test_mask_conversion_as_tensor(mocker: MockerFixture) -> None:
+        """Test that the function correctly converts the image to a tensor (normalized to 0, 1).
+
+        Test cases:
+        - Value 0 remains non-anomalous (0)
+        - Value 236 (>0) becomes anomalous (1)
+        - Value 255 becomes anomalous (1)
+        """
+        mocker.patch(
+            "anomalib.data.utils.image.Image.open",
+            return_value=Image.fromarray(np.array([[0, 236], [255, 0]], dtype=np.uint8)),
+        )
+        result = read_mask("dummy_path.png", as_tensor=True)
+
+        assert isinstance(result, torch.Tensor)
+        assert result.dtype == torch.uint8
+        assert torch.equal(result, torch.tensor([[0, 1], [1, 0]], dtype=torch.uint8))


### PR DESCRIPTION
## 📝 Description

- **Issue**: When loading gt masks with the `read_mask` function, only pixel values of 255 would be set as anomalous (value of 1) when loaded with `as_tensor=True`
- **Where did it cause problems**? The [MVTecLOCODataset](https://github.com/open-edge-platform/anomalib/blob/3fe113ff08a1add0e39406ceec583f4ec7a9cca8/src/anomalib/data/datasets/image/mvtec_loco.py#L64) has anomalous pixels with values below 255, since it assigns different values for different anomalies, leading to empty gt masks
- **Fix**: in [`read_mask(...)`](https://github.com/open-edge-platform/anomalib/blob/3fe113ff08a1add0e39406ceec583f4ec7a9cca8/src/anomalib/data/utils/image.py#L323) instead of dividing by 255 and then casting to torch.uint8 (which results in 0 values for any pixel values less than 255), pixels are set as anomalous (1) if they have a value greater than 0
- 🛠️ Fixes #2803

## ✨ Changes

- Changed `read_mask` function in src/anomalib/data/utils/image.py
- Added basic unit tests in tests/unit/data/utils/test_image.py

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ♻️ Refactor (non-breaking change which refactors the code base)
- [ ] ⚡️ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [x] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🏗️ CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] ~~📚 I have made the necessary updates to the documentation (if applicable).~~ Not applicable
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
