### PR TITLE
fix: remove in-place operations causing errors during ONNX export wit…

### DIFF
--- a/src/anomalib/models/video/ai_vad/density.py
+++ b/src/anomalib/models/video/ai_vad/density.py
@@ -246,22 +246,28 @@ class CombinedDensityEstimator(BaseDensityEstimator):
         """
         n_regions = next(iter(features.values())).shape[0]
         device = next(iter(features.values())).device
-        region_scores = torch.zeros(n_regions).to(device)
-        image_score = 0
+        region_scores_list = []
+        image_scores_list = []
+    
         if self.use_velocity_features and features[FeatureType.VELOCITY].numel():
             velocity_scores = self.velocity_estimator.predict(features[FeatureType.VELOCITY])
-            region_scores += velocity_scores
-            image_score += velocity_scores.max()
+            region_scores_list.append(velocity_scores)
+            image_scores_list.append(velocity_scores.max())
+        
         if self.use_deep_features and features[FeatureType.DEEP].numel():
             deep_scores = self.appearance_estimator.predict(features[FeatureType.DEEP])
-            region_scores += deep_scores
-            image_score += deep_scores.max()
+            region_scores_list.append(deep_scores)
+            image_scores_list.append(deep_scores.max())
+        
         if self.use_pose_features and features[FeatureType.POSE].numel():
             pose_scores = self.pose_estimator.predict(features[FeatureType.POSE])
-            region_scores += pose_scores
-            image_score += pose_scores.max()
+            region_scores_list.append(pose_scores)
+            image_scores_list.append(pose_scores.max())
+        
+        region_scores = sum(region_scores_list) if region_scores_list else torch.zeros(n_regions, device=device)
+        image_score = sum(image_scores_list) if image_scores_list else torch.tensor(0.0, device=device)
+        
         return region_scores, image_score
-
 
 class GroupedKNNEstimator(DynamicBufferMixin, BaseDensityEstimator):
     """Grouped KNN density estimator.


### PR DESCRIPTION
## 📝 Description

Fix in-place tensor mutations in `CombinedDensityEstimator.predict` to support ONNX export with `dynamic_axes`. All `+=` calls have been replaced by accumulating scores in lists and combining via `sum()`, eliminating the “cannot mutate tensors with frozen storage” error.

These changes are essential for any future effort to export `CombinedDensityEstimator` as a standalone ONNX module. By removing all in-place tensor mutations and adding full support for dynamic_axes, the estimator can be reliably converted into ONNX format on its own—making it much easier to import, deploy, and version independently of the rest of the AI-VAD pipeline

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ♻️ Refactor (non-breaking change which refactors the code base)
- [ ] ⚡️ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🏗️ CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
