### PR TITLE
♻️ refactor(cli): show import error in CLI

### DIFF
--- a/src/anomalib/cli/cli.py
+++ b/src/anomalib/cli/cli.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 Intel Corporation
+# Copyright (C) 2023-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 """Anomalib Command Line Interface.
@@ -37,8 +37,9 @@ try:
     from anomalib.models import AnomalibModule
     from anomalib.utils.config import update_config
 
-except ImportError:
+except ImportError as error:
     _LIGHTNING_AVAILABLE = False
+    logger.warning(f"Import failed: {error}. Please install the required dependencies.")
 
 
 class AnomalibCLI:

--- a/src/anomalib/utils/config.py
+++ b/src/anomalib/utils/config.py
@@ -509,7 +509,13 @@ def _show_warnings(config: DictConfig | ListConfig | Namespace) -> None:
         specifically checking the ``clip_length_in_frames`` parameter in the data
         configuration section.
     """
-    if "clip_length_in_frames" in config.data and config.data.init_args.clip_length_in_frames > 1:
+    if (
+        "data" in config
+        and config.data is not None
+        and "clip_length_in_frames" in config.data
+        and "init_args" in config.data
+        and config.data.init_args.clip_length_in_frames > 1
+    ):
         logger.warning(
             "Anomalib's models and visualizer are currently not compatible with video datasets with a clip length > 1. "
             "Custom changes to these modules will be needed to prevent errors and/or unpredictable behaviour.",


### PR DESCRIPTION
## 📝 Description

- Currently it is opaque to the users why the CLI fails. This minor change also shows the import error

### Example

```diff
anomalib train --model Padim
To use other subcommand using `anomalib install`
+Import failed: No module named 'FrEIA'. Please install the required dependencies.
Usage: anomalib [-h] [-c CONFIG] [--print_config [=flags]] {install} ...
error: argument subcommand: invalid choice: 'train' (choose from 'install')
```


## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
