### PR TITLE
📚 fix(docs): fixed the "Anomalib in 15 Minutes" train and inference code

### DIFF
--- a/docs/source/markdown/get_started/anomalib.md
+++ b/docs/source/markdown/get_started/anomalib.md
@@ -52,7 +52,7 @@ interfaces, and might be easier for those who would like to use anomalib off-the
 
 ```{literalinclude} ../../../../examples/api/01_getting_started/basic_training.py
 :language: python
-:lines: 10-34
+:lines: 10-53
 ```
 
 :::
@@ -61,6 +61,7 @@ interfaces, and might be easier for those who would like to use anomalib off-the
 
 ```{literalinclude} ../../../../examples/cli/01_getting_started/basic_training.sh
 :language: bash
+:lines: 10-33
 ```
 
 :::
@@ -81,6 +82,7 @@ Anomalib includes multiple inferencing scripts, including Torch, Lightning, Grad
 
 ```{literalinclude} ../../../../examples/api/01_getting_started/basic_inference.py
 :language: python
+:lines: 10-40
 ```
 
 :::
@@ -104,8 +106,9 @@ Anomalib includes multiple inferencing scripts, including Torch, Lightning, Grad
 :::{tab-item} API
 :sync: label-1
 
-```{code-block} python
-
+```{literalinclude} ../../../../examples/api/01_getting_started/basic_torch_inference.py
+:language: python
+:lines: 10-11
 ```
 
 :::
@@ -129,8 +132,9 @@ Anomalib includes multiple inferencing scripts, including Torch, Lightning, Grad
 :::{tab-item} API
 :sync: label-1
 
-```{code-block} python
-
+```{literalinclude} ../../../../examples/api/01_getting_started/basic_openvino_inference.py
+:language: python
+:lines: 10-28
 ```
 
 :::

--- a/examples/api/01_getting_started/basic_openvino_inference.py
+++ b/examples/api/01_getting_started/basic_openvino_inference.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 """Getting Started with Anomalib Inference using the Python API.

--- a/examples/api/01_getting_started/basic_openvino_inference.py
+++ b/examples/api/01_getting_started/basic_openvino_inference.py
@@ -8,32 +8,21 @@ using the Anomalib Python API.
 """
 
 # 1. Import required modules
-from anomalib.data import PredictDataset
-from anomalib.engine import Engine
-from anomalib.models import Patchcore
+from anomalib.deploy import OpenVINOInferencer
 
-# 2. Initialize the model and load weights
-model = Patchcore()
-engine = Engine()
-
-# 3. Prepare test data
-# You can use a single image or a folder of images
-dataset = PredictDataset(
-    path="path/to/test/images",
-    image_size=(256, 256),
+# 2. Initialize the inferencer
+inferencer = OpenVINOInferencer(
+    path="/path/to/openvino/model.bin",
 )
 
 # 4. Get predictions
-predictions = engine.predict(
-    model=model,
-    dataset=dataset,
-    ckpt_path="path/to/model.ckpt",
+predictions = inferencer.predict(
+    image="/path/to/image.png",
 )
 
 # 5. Access the results
 if predictions is not None:
     for prediction in predictions:
-        image_path = prediction.image_path
         anomaly_map = prediction.anomaly_map  # Pixel-level anomaly heatmap
         pred_label = prediction.pred_label  # Image-level label (0: normal, 1: anomalous)
         pred_score = prediction.pred_score  # Image-level anomaly score

--- a/examples/api/01_getting_started/basic_torch_inference.py
+++ b/examples/api/01_getting_started/basic_torch_inference.py
@@ -1,0 +1,11 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Getting Started with Anomalib Inference using the Python API.
+
+This example shows how to perform inference on a trained model
+using the Anomalib Python API.
+"""
+
+# TorchInferencer is a legacy inferencer. Consider using Engine.predict() instead,
+# which provides a more modern and feature-rich interface for model inference.

--- a/examples/api/01_getting_started/basic_torch_inference.py
+++ b/examples/api/01_getting_started/basic_torch_inference.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 """Getting Started with Anomalib Inference using the Python API.

--- a/examples/api/01_getting_started/basic_training.py
+++ b/examples/api/01_getting_started/basic_training.py
@@ -9,8 +9,9 @@ using the Anomalib Python API.
 
 # 1. Import required modules
 from anomalib.data import MVTecAD
+from anomalib.deploy import ExportType
 from anomalib.engine import Engine
-from anomalib.models import EfficientAd
+from anomalib.models import Patchcore
 
 # 2. Create a dataset
 # MVTecAD is a popular dataset for anomaly detection
@@ -19,15 +20,29 @@ datamodule = MVTecAD(
     category="bottle",  # MVTec category to use
     train_batch_size=32,  # Number of images per training batch
     eval_batch_size=32,  # Number of images per validation/test batch
-    num_workers=8,  # Number of parallel processes for data loading
 )
 
 # 3. Initialize the model
-# EfficientAd is a good default choice for beginners
-model = EfficientAd()
+# Patchcore is a good choice for beginners
+model = Patchcore(
+    num_neighbors=6,  # Override default model settings
+)
 
 # 4. Create the training engine
-engine = Engine(max_epochs=10)  # Train for 10 epochs
+engine = Engine(
+    max_epochs=1,  # Override default trainer settings
+)
 
 # 5. Train the model
+# This produces a lightning model (.ckpt)
 engine.fit(datamodule=datamodule, model=model)
+
+# 6. Test the model performance
+test_results = engine.test(datamodule=datamodule, model=model)
+
+# 7. Export the model
+# Different formats are available: Torch, OpenVINO, ONNX
+engine.export(
+    model=model,
+    export_type=ExportType.OPENVINO,
+)

--- a/examples/cli/01_getting_started/basic_training.sh
+++ b/examples/cli/01_getting_started/basic_training.sh
@@ -8,19 +8,26 @@
 # This example shows the basic steps to train an anomaly detection model.
 
 # 1. Basic Training
-# Train a model using default configuration (recommended for beginners)
+# Train and test a model using default configuration on MVTecAD bottle (default category)
 echo "Training with default configuration..."
-anomalib train --model efficient_ad
+anomalib train --model Patchcore --data anomalib.data.MVTecAD
 
 # 2. Training with Basic Customization
-# Customize basic parameters like batch size and epochs
+# Customize basic parameters like batch size and epochs.
+# For example `EfficientAd` requires a train batch size of 1
 echo -e "\nTraining with custom parameters..."
-anomalib train --model efficient_ad \
-    --data.train_batch_size 32 \
-    --trainer.max_epochs 10
+anomalib train --model EfficientAd --data anomalib.data.MVTecAD \
+    --data.category hazelnut \
+    --data.train_batch_size 1 \
+    --trainer.max_epochs 200
 
-# 3. Using a Different Dataset
-# Train on a specific category of MVTecAD dataset
-echo -e "\nTraining on MVTecAD bottle category..."
-anomalib train --model efficient_ad \
-    --data.category bottle
+# 3. Train with config file
+# Train with a custom config file
+echo -e "\nTraining with config file..."
+anomalib train --config path/to/config.yaml
+
+# 4. Export a trained model into OpenVINO
+echo .e "\nExporting model into OpenVINO..."
+anomalib export --model Patchcore \
+        --ckpt_path /path/to/model.ckpt \
+        --export_type OPENVINO


### PR DESCRIPTION
After reading #2892, I fixed the 'Anomalib in 15 Minutes' train and inference code to match 2.1.0 anomalib version.

## 📝 Description

- Changed `basic_training.py` to use **Patchcore** instead of EfficientAD, with examples of overriding config.
- Added test and export example in `basic_training.py`.
- Changed `basic_inference.py` to use Patchcore with `engine.predict()`.
- Added `basic_openvino_inference.py` to demonstrate image inference with `OpenVINOInferencer`.
- Added `basic_torch_inference.py` file with legacy warning.  
  ⚠️ Note: `TorchInferencer` is marked as legacy. Consider removing this example if maintainers prefer focusing only on `Engine.predict()`.
- Updated `basic_training.sh` to match the behavior of `basic_training.py`.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [x] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [x] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
