### PR TITLE
🔨 fix(semgrep): ignore uv.lock in semgrep

### DIFF
--- a/.github/actions/security/semgrep/action.yaml
+++ b/.github/actions/security/semgrep/action.yaml
@@ -141,6 +141,7 @@ runs:
           --error \
           --timeout "$INPUTS_TIMEOUT" \
           --metrics=off \
+          --exclude "uv.lock" \
           ${FILES}
         exit_code="$?"
         echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
@@ -151,6 +152,7 @@ runs:
           ${SEMGREP_SEVERITY} \
           --error \
           --metrics=off \
+          --exclude "uv.lock" \
           --timeout "$INPUTS_TIMEOUT" \
           --"$INPUTS_OUTPUT_FORMAT" \
           -o "${REPORT_FILE}" \


### PR DESCRIPTION
## 📝 Description

- semgrep fails in certain actions as it checks uv.lock and complains about api being present.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [x] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
