### PR TITLE
🐛 fix(inspect): Use null pool for async engine

### DIFF
--- a/application/backend/src/db/engine.py
+++ b/application/backend/src/db/engine.py
@@ -15,10 +15,16 @@ from sqlalchemy.pool.impl import NullPool
 from db.schema import Base
 from settings import get_settings
 
-DATABASE_URL = "sqlite+aiosqlite:///.inspect.db"
 settings = get_settings()
 
-async_engine = create_async_engine(DATABASE_URL, echo=False)
+async_engine = create_async_engine(
+    settings.database_url,
+    connect_args={"check_same_thread": False, "timeout": 30},
+    # Using NullPool to disable connection pooling, which is necessary for SQLite when using multiprocessing
+    # https://docs.sqlalchemy.org/en/20/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork
+    poolclass=NullPool,
+    echo=settings.db_echo,
+)
 async_session = async_sessionmaker(async_engine, expire_on_commit=False)
 
 sync_engine = create_engine(

--- a/application/backend/src/settings.py
+++ b/application/backend/src/settings.py
@@ -31,7 +31,9 @@ class Settings(BaseSettings):
 
     # Database
     database_url: str = Field(
-        default="sqlite:///./data/geti_inspect.db", alias="DATABASE_URL", description="Database connection URL"
+        default="sqlite+aiosqlite:///./data/geti_inspect.db?journal_mode=WAL",
+        alias="DATABASE_URL",
+        description="Database connection URL",
     )
     db_echo: bool = Field(default=False, alias="DB_ECHO")
 


### PR DESCRIPTION
## 📝 Description

This fixes an issue where the training worker wasn't able to get a lock on the sqlite database. As a result when it tried to get all pending jobs the query it would execute would stall indefinitely.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
