### PR TITLE
chore(gitattributes): Remove uv.lock LFS entry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,3 @@
 # Ignore *ipynb files to detect the language.
 # This is because GitHub misdetects the repo language when ipynb files are included.
 *.ipynb filter=lfs diff=lfs merge=lfs -text
-uv.lock filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Stop treating uv.lock as a Git LFS-tracked file by removing its .gitattributes rule to avoid incorrect LFS handling.

## 📝 Description

- Provide a clear summary of the changes and the issue that has been addressed.
- 🛠️ Fixes # (issue number)

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
