### PR TITLE
🐛 fix(metrics): disable mps for torch metrics 

### DIFF
--- a/src/anomalib/metrics/threshold/f1_adaptive_threshold.py
+++ b/src/anomalib/metrics/threshold/f1_adaptive_threshold.py
@@ -34,6 +34,8 @@ Note:
 """
 
 import logging
+from collections.abc import Generator
+from contextlib import contextmanager
 
 import torch
 
@@ -43,6 +45,30 @@ from anomalib.metrics.precision_recall_curve import BinaryPrecisionRecallCurve
 from .base import Threshold
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def handle_mac(metric: "_F1AdaptiveThreshold") -> Generator[None, None, None]:
+    """Temporarily move tensors to CPU on macOS/MPS and restore after.
+
+    This context manager checks whether the provided metric instance has
+    predictions on an MPS device. If so, it moves both predictions and
+    targets to CPU for the duration of the context and restores them to
+    the original device on exit.
+    """
+    # Check if we have any predictions and if they're on MPS
+    if bool(metric.preds) and metric.preds[0].is_mps:
+        original_device = metric.preds[0].device
+        metric.preds = [pred.cpu() for pred in metric.preds]
+        metric.target = [target.cpu() for target in metric.target]
+        try:
+            yield
+        finally:
+            # Restore to original device
+            metric.preds = [pred.to(original_device) for pred in metric.preds]
+            metric.target = [target.to(original_device) for target in metric.target]
+    else:
+        yield
 
 
 class _F1AdaptiveThreshold(BinaryPrecisionRecallCurve, Threshold):
@@ -94,16 +120,8 @@ class _F1AdaptiveThreshold(BinaryPrecisionRecallCurve, Threshold):
             )
             logging.warning(msg)
 
-        precision, recall, thresholds = super().compute()
-
-        # torchmetrics uses sklearn precision recall curve format:
-        # https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_recall_curve.html
-        # precision has shape (n_thresholds + 1,), where last element is 1.0
-        # recall has shape (n_thresholds + 1,), where last element is 0.0
-        if precision.numel() == thresholds.numel() + 1:
-            # Drop last element
-            precision = precision[:-1]
-            recall = recall[:-1]
+        with handle_mac(self):
+            precision, recall, thresholds = super().compute()
 
         f1_score = (2 * precision * recall) / (precision + recall + 1e-10)
 


### PR DESCRIPTION
## 📝 Description

Bug: on Mac, the optimal threshold index is out of range.

Torchmetrics returns `NaN` values when computing the f1 score with `device=mps`.

Solution: use CPU instead of mps

@ashwinvaidya17 thanks for the suggestion.


## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
