### PR TITLE
fix(ci): disable `torch` upgrade in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,6 +62,13 @@
       matchDepTypes: ["project.optional-dependencies"],
     },
 
+    // torch is upgraded manually
+    {
+      enabled: false,
+      matchDatasources: ["pypi"],
+      matchDepNames: ["torch"],
+    },
+
     // Group GitHub Actions updates
     {
       enabled: true,
@@ -78,17 +85,6 @@
       matchDatasources: ["github-releases"],
       matchDepNames: ["python"],
       matchDepTypes: ["uses-with"],
-    },
-  ],
-
-  // is used to upgrade Zizmor version
-  customManagers: [
-    {
-      fileMatch: ["^\\.github/actions/security/zizmor/[^/]+\\.ya?ml$"],
-      //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
-      matchStrings: [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+default: (?<currentValue>.*)",
-      ],
     },
   ],
 


### PR DESCRIPTION
## 📝 Description

This PR updates Renovate config to disable `torch`  (to prevent such PRs https://github.com/open-edge-platform/anomalib/pull/3081) and `zizmor` upgrades (in subsequent PR local action will be replaced with https://github.com/open-edge-platform/geti-ci/tree/main/actions/zizmor).

Testsed in fork.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [x] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
