### PR TITLE
fix(inspect): Remove alpha channel before inference

### DIFF
--- a/application/backend/src/services/model_service.py
+++ b/application/backend/src/services/model_service.py
@@ -335,6 +335,10 @@ class ModelService:
         if numpy_image is None:
             raise ValueError("Failed to decode image")
 
+        # Remove alpha channel
+        if len(numpy_image.shape) == 3 and numpy_image.shape[-1] == 4:
+            numpy_image = cv2.cvtColor(numpy_image, cv2.COLOR_RGBA2RGB)
+
         # Run prediction
         pred = inference_model.predict(numpy_image)
 


### PR DESCRIPTION
## 📝 Description

When running inference on png images the `:predict` endpoint would return a 500 internal server error. The server logs include the following message,
```
Can't set the input tensor with index: 0, because the model input (shape=[?,3,?,?]) and the tensor (shape=(1.1085.1905.4)) are incompatible
```

here my image was a 1905 x 1085 png image.
This error gets fixed by removing the alpha channel from the image.

To me ideally this should be done in Anomalib's preprocessors. However I'm not sure where to do this.

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)