### PR TITLE
fix(inspect): stream uses wrong color channels

### DIFF
--- a/application/backend/src/webrtc/stream.py
+++ b/application/backend/src/webrtc/stream.py
@@ -72,7 +72,7 @@ class InferenceVideoStreamTrack(VideoStreamTrack):
             logger.trace("Received the frame from the stream_queue.")
 
             # Convert numpy array to VideoFrame
-            frame = VideoFrame.from_ndarray(frame_data, format="bgr24")
+            frame = VideoFrame.from_ndarray(frame_data, format="rgb24")
             frame.pts = pts
             frame.time_base = time_base
             return frame


### PR DESCRIPTION
## 📝 Description

oneliner: webrtc stream used `bgr24` instead of `rgb24` (previously this was correct because `_read_frame` used bgr)

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
