### PR TITLE
docs(data): fix typo in augmentation docstring

### DIFF
--- a/src/anomalib/data/datamodules/base/image.py
+++ b/src/anomalib/data/datamodules/base/image.py
@@ -63,7 +63,7 @@ class AnomalibDataModule(LightningDataModule, ABC):
         train_batch_size (int): Batch size used by the train dataloader.
         eval_batch_size (int): Batch size used by the val and test dataloaders.
         num_workers (int): Number of workers used by the train, val and test dataloaders.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/depth/adam_3d.py
+++ b/src/anomalib/data/datamodules/depth/adam_3d.py
@@ -59,7 +59,7 @@ class ADAM3D(AnomalibDataModule):
             Defaults to ``32``.
         num_workers (int, optional): Number of workers for data loading.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/depth/folder_3d.py
+++ b/src/anomalib/data/datamodules/depth/folder_3d.py
@@ -58,7 +58,7 @@ class Folder3D(AnomalibDataModule):
             Defaults to ``32``.
         num_workers (int, optional): Number of workers for data loading.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/depth/mvtec_3d.py
+++ b/src/anomalib/data/datamodules/depth/mvtec_3d.py
@@ -64,7 +64,7 @@ class MVTec3D(AnomalibDataModule):
             Defaults to ``32``.
         num_workers (int, optional): Number of workers for data loading.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/image/btech.py
+++ b/src/anomalib/data/datamodules/image/btech.py
@@ -74,7 +74,7 @@ class BTech(AnomalibDataModule):
             Defaults to ``32``.
         num_workers (int, optional): Number of workers.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/image/datumaro.py
+++ b/src/anomalib/data/datamodules/image/datumaro.py
@@ -58,7 +58,7 @@ class Datumaro(AnomalibDataModule):
             Defaults to ``32``.
         num_workers (int, optional): Number of workers.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/image/folder.py
+++ b/src/anomalib/data/datamodules/image/folder.py
@@ -67,7 +67,7 @@ class Folder(AnomalibDataModule):
             Defaults to ``32``.
         num_workers (int): Number of workers for data loading.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/image/kolektor.py
+++ b/src/anomalib/data/datamodules/image/kolektor.py
@@ -51,7 +51,7 @@ class Kolektor(AnomalibDataModule):
             Defaults to ``32``.
         num_workers (int, optional): Number of workers.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/image/mpdd.py
+++ b/src/anomalib/data/datamodules/image/mpdd.py
@@ -63,7 +63,7 @@ class MPDD(AnomalibDataModule):
             Defaults to ``32``.
         num_workers (int, optional): Number of workers.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/image/mvtecad.py
+++ b/src/anomalib/data/datamodules/image/mvtecad.py
@@ -80,7 +80,7 @@ class MVTecAD(AnomalibDataModule):
             Defaults to ``32``.
         num_workers (int, optional): Number of workers.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/image/vad.py
+++ b/src/anomalib/data/datamodules/image/vad.py
@@ -69,7 +69,7 @@ class VAD(AnomalibDataModule):
             Defaults to ``32``.
         num_workers (int, optional): Number of workers.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/image/visa.py
+++ b/src/anomalib/data/datamodules/image/visa.py
@@ -79,7 +79,7 @@ class Visa(AnomalibDataModule):
             Defaults to ``32``.
         num_workers (int, optional): Number of workers for data loading.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/video/avenue.py
+++ b/src/anomalib/data/datamodules/video/avenue.py
@@ -102,7 +102,7 @@ class Avenue(AnomalibVideoDataModule):
             Defaults to ``32``.
         num_workers (int): Number of workers.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/video/shanghaitech.py
+++ b/src/anomalib/data/datamodules/video/shanghaitech.py
@@ -87,7 +87,7 @@ class ShanghaiTech(AnomalibVideoDataModule):
             Defaults to ``32``.
         num_workers (int): Number of workers for data loading.
             Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.

--- a/src/anomalib/data/datamodules/video/ucsd_ped.py
+++ b/src/anomalib/data/datamodules/video/ucsd_ped.py
@@ -46,7 +46,7 @@ class UCSDped(AnomalibVideoDataModule):
         eval_batch_size (int): Batch size for validation and testing.
             Defaults to ``8``.
         num_workers (int): Number of workers for data loading. Defaults to ``8``.
-        train_augmentations (Transform | None): Augmentations to apply dto the training images
+        train_augmentations (Transform | None): Augmentations to apply to the training images
             Defaults to ``None``.
         val_augmentations (Transform | None): Augmentations to apply to the validation images.
             Defaults to ``None``.


### PR DESCRIPTION
## 📝 Description

Fix a minor typo in the docstring for the augmentation arguments: "apply dto" -> "apply to".
No functional or behavioral changes.

- 🛠️ Fixes # N/A

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [x] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [x] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.