### PR TITLE
fix(model): Fix AnomalyDINO aspect-ratio preserving resize preprocessing

### DIFF
--- a/src/anomalib/models/image/anomaly_dino/torch_model.py
+++ b/src/anomalib/models/image/anomaly_dino/torch_model.py
@@ -303,7 +303,7 @@ class AnomalyDINOModel(DynamicBufferMixin, nn.Module):
         image_score = self.mean_top1p(distances_full)
 
         # Generate final anomaly map
-        # Upsample to cropped dimensions, then pad back to original size to maintain alignment
+        # Reshape to grid, upsample to padded  dimensions, then pad back to original size to maintain alignment
         anomaly_map = distances_full.view(b, 1, *grid_size)
         anomaly_map = self.anomaly_map_generator(anomaly_map, (cropped_h, cropped_w))
         # Pad anomaly map back to original size (replicating edge values)


### PR DESCRIPTION
AnomalyDINO fails when input image dimensions are not divisible by the DINOv2 patch size (14). This commonly occurs with aspect-ratio preserving resize preprocessing.

Solution
Center-crop input images to dimensions divisible by 14, then pad the anomaly map back to original size. This maintains spatial alignment without offsetting the map. 

Fixes : #3221

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
