### PR TITLE
docs: Use F1Max instead of F1Score in validation metrics examples

### DIFF
--- a/docs/source/markdown/guides/how_to/evaluation/evaluator.md
+++ b/docs/source/markdown/guides/how_to/evaluation/evaluator.md
@@ -68,12 +68,15 @@ engine.test(model, datamodule=datamodule)  # make sure to create a datamodule fi
 You can configure different metrics for validation and testing:
 
 ```python
-from anomalib.metrics import Evaluator, AUROC, F1Score
+from anomalib.metrics import Evaluator, AUROC, F1Score, F1Max
 
 # Validation metrics
+# Note: Use F1Max for validation as it finds the optimal F1 score across
+# different thresholds. F1Score requires pred_label which is only available
+# after thresholds are computed in the test phase.
 val_metrics = [
     AUROC(fields=["pred_score", "gt_label"]),     # Image-level AUROC
-    F1Score(fields=["pred_label", "gt_label"])    # Image-level F1
+    F1Max(fields=["pred_score", "gt_label"]),     # Maximum F1 score
 ]
 
 # Test metrics (more comprehensive)
@@ -153,9 +156,10 @@ Balance between accuracy and computational efficiency:
 # Memory-Efficient Configuration
 evaluator = Evaluator(
     # Validation: Light-weight metrics for quick feedback
+    # Use F1Max for validation - it finds optimal F1 across thresholds
     val_metrics=[
-        F1Score(fields=["pred_label", "gt_label"]),
-        AUROC(fields=["pred_score", "gt_label"])
+        AUROC(fields=["pred_score", "gt_label"]),
+        F1Max(fields=["pred_score", "gt_label"])
     ],
     # Testing: Comprehensive evaluation
     test_metrics=[


### PR DESCRIPTION
## 📝 Description

Problem: F1Score in validation metrics causes ValueError during validation phase.
Fix: Use F1Max in validation metrics as it works with pred_score and finds optimal F1 across thresholds.

- 🛠️ Fixes  #3214


## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
