### PR TITLE
fix(pyproject): Pin pandas <3.0.0 to prevent enum comparison issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "imagecodecs",
     "kornia>=0.6.6",
     # Data science and analysis
-    "pandas>=1.1.0",
+    "pandas>=1.1.0,<3.0.0",  # Temporary pin: pandas 3.0 breaks DirType enum comparisons in DataFrame.loc (issue #3303)
     "matplotlib>=3.4.3",
     "scikit-learn",
 ]


### PR DESCRIPTION
Pandas 3.0 breaks DirType enum comparisons in DataFrame.loc operations. Pin to <3.0.0 until the codebase is updated to use .value for enum comparisons (issue #3303).
Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
