### PR TITLE
chore: remove pip from the base image

### DIFF
--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -44,11 +44,11 @@ g++ \
 && apt-get clean
 
 # Remove pip because uv is used as the package manager.
-# This reduces attack surface and image size (a little bit)
+# This reduces attack surface and image size (a little bit).
 # python:3.13-slim only ships pip (not setuptools/wheel).
-RUN pip3 uninstall -y --root-user-action=ignore pip \
+ENV PIP_ROOT_USER_ACTION=ignore
+RUN python -m pip uninstall -y pip \ 
     && rm -rf /root/.cache/pip
-
 ENV PATH=/app/.venv/bin:$PATH
 WORKDIR /app
 


### PR DESCRIPTION
## 📝 Description

Remove pip from the base image because uv is used as the package manager. This reduces attack surface and image size (a little bit).

## ✨ Changes

Select what type of change your PR is:

- [x] 🔧 Chore (general maintenance)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [x] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
