### PR TITLE
refactor(data): expose item material as category

### DIFF
--- a/examples/configs/data/kaputt.yaml
+++ b/examples/configs/data/kaputt.yaml
@@ -1,6 +1,7 @@
 class_path: anomalib.data.Kaputt
 init_args:
   root: ./datasets/kaputt
+  category: book_other
   train_batch_size: 32
   eval_batch_size: 32
   num_workers: 8

--- a/src/anomalib/data/datamodules/image/kaputt.py
+++ b/src/anomalib/data/datamodules/image/kaputt.py
@@ -73,6 +73,9 @@ class Kaputt(AnomalibDataModule):
     Args:
         root (Path | str): Path to the root of the dataset.
             Defaults to ``"./datasets/kaputt"``.
+        category (str): Category of the dataset. Defaults to ``"book_other"``.
+            Kaputt uses `item_material` which is exposed as category to make the
+            API consistent with other datasets.
         train_batch_size (int, optional): Training batch size.
             Defaults to ``32``.
         eval_batch_size (int, optional): Test batch size.
@@ -139,6 +142,7 @@ class Kaputt(AnomalibDataModule):
     def __init__(
         self,
         root: Path | str = "./datasets/kaputt",
+        category: str = "book_other",
         train_batch_size: int = 32,
         eval_batch_size: int = 32,
         num_workers: int = 8,
@@ -170,6 +174,7 @@ class Kaputt(AnomalibDataModule):
         )
 
         self.root = Path(root)
+        self.category = category
         self.image_type = image_type
         self.use_reference = use_reference
 
@@ -185,12 +190,14 @@ class Kaputt(AnomalibDataModule):
         self.train_data = KaputtDataset(
             split=Split.TRAIN,
             root=self.root,
+            category=self.category,
             image_type=self.image_type,
             use_reference=self.use_reference,
         )
         self.test_data = KaputtDataset(
             split=Split.TEST,
             root=self.root,
+            category=self.category,
             image_type=self.image_type,
             use_reference=False,  # Don't use reference for test
         )
@@ -200,6 +207,7 @@ class Kaputt(AnomalibDataModule):
             self.val_data = KaputtDataset(
                 split=Split.VAL,
                 root=self.root,
+                category=self.category,
                 image_type=self.image_type,
                 use_reference=False,  # Don't use reference for validation
             )

--- a/src/anomalib/data/datasets/image/kaputt.py
+++ b/src/anomalib/data/datasets/image/kaputt.py
@@ -83,6 +83,9 @@ class KaputtDataset(AnomalibDataset):
     Args:
         root (Path | str): Path to root directory containing the dataset.
             Defaults to ``"./datasets/kaputt"``.
+        category (str): Category of the dataset. Defaults to ``"book_other"``.
+            Kaputt uses `item_material` which is exposed as category to make the
+            API consistent with other datasets.
         augmentations (Transform, optional): Augmentations that should be applied
             to the input images. Defaults to ``None``.
         split (str | Split | None, optional): Dataset split - ``Split.TRAIN``,
@@ -124,6 +127,7 @@ class KaputtDataset(AnomalibDataset):
     def __init__(
         self,
         root: Path | str = "./datasets/kaputt",
+        category: str = "book_other",
         augmentations: Transform | None = None,
         split: str | Split | None = None,
         image_type: str = "image",
@@ -137,6 +141,7 @@ class KaputtDataset(AnomalibDataset):
         self.use_reference = use_reference
         self.samples = make_kaputt_dataset(
             self.root,
+            category=category,
             split=self.split,
             image_type=self.image_type,
             use_reference=self.use_reference,
@@ -145,6 +150,7 @@ class KaputtDataset(AnomalibDataset):
 
 def make_kaputt_dataset(
     root: str | Path,
+    category: str | None = None,
     split: str | Split | None = None,
     image_type: str = "image",
     use_reference: bool = False,
@@ -160,6 +166,7 @@ def make_kaputt_dataset(
 
     Args:
         root (Path | str): Path to dataset root directory.
+        category (str | None, optional): Category of the dataset. Defaults to ``None``.
         split (str | Split | None, optional): Dataset split (train, val, or test).
             Defaults to ``None`` which loads all splits.
         image_type (str): Type of images - "image" for full images or "crop"
@@ -223,6 +230,10 @@ def make_kaputt_dataset(
         samples["item_material"] = query_df["item_material"].fillna("")
         samples["defect_types"] = query_df["defect_types"].fillna("")
         samples["split"] = anomalib_name
+
+        # Filter samples by item material if category is provided
+        if category:
+            samples = samples[samples["item_material"] == category]
 
         # Label assignment
         samples.loc[query_df["defect"] == False, "label_index"] = LabelName.NORMAL  # noqa: E712


### PR DESCRIPTION
## 📝 Description

- Exposes item material as category. We should reconsider this though. The models should fetch the reference images per material in their `setup` method. Meanwhile this is still a better alternative than using the entire dataset for training.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
