### PR TITLE
fix(github-actions): Sidecar dependacies installation fix

### DIFF
--- a/.github/workflows/tauri-build.yaml
+++ b/.github/workflows/tauri-build.yaml
@@ -112,7 +112,7 @@ jobs:
   #       working-directory: application/backend
   #       run: |
   #         uv sync --no-dev --extra ${{ matrix.accelerator }}
-  #         uv pip install pyinstaller
+  #         uv pip install pyinstaller==6.19.0
   #         source .venv/bin/activate
   #         cd ../binary/sidecar
   #         uv run --active pyinstaller anomalib_studio.spec
@@ -241,7 +241,7 @@ jobs:
           MATRIX_ACCELERATOR: ${{ matrix.accelerator }}
         run: |
           uv sync --no-dev --extra $env:MATRIX_ACCELERATOR
-          uv pip install pyinstaller
+          uv pip install pyinstaller==6.19.0
           .\.venv\Scripts\Activate.ps1
           Push-Location ..\binary\sidecar
           uv run --active pyinstaller anomalib_studio.spec
@@ -366,7 +366,7 @@ jobs:
   #       working-directory: application/backend
   #       run: |
   #         uv sync --no-dev
-  #         uv pip install pyinstaller
+  #         uv pip install pyinstaller==6.19.0
   #         source .venv/bin/activate
   #         cd ../binary/sidecar
   #         uv run --active pyinstaller anomalib_studio.spec


### PR DESCRIPTION
## 📝 Description

Using the `uv run` command with the `--active` and `--with` flags created a separate virtual environment, which resulted in the torch+xpu package being missing and the device being missing from the list of training devices.

Fixes #3405 

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
