### PR TITLE
feat(ci): add auto-approval flow for Renovate "safe" PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,9 @@
 # Anomalib Studio
 /application/ui                                             @MarkRedeman @maxxgx @ActiveChooN
 /application/backend                                        @maxxgx @rajeshgangireddy @MarkRedeman
+/application/backend/uv.lock                                @maxxgx @rajeshgangireddy @MarkRedeman @sys-geti
+/application/docker/Dockerfile                              @maxxgx @rajeshgangireddy @MarkRedeman @sys-geti
+/application/binary/tauri/src-tauri/Cargo.lock              @MarkRedeman @maxxgx @ActiveChooN @sys-geti
 
 # Tests
 /tests/                                                     @samet-akcay @ashwinvaidya17 @rajeshgangireddy
@@ -62,6 +65,7 @@
 /setup.py                                                   @samet-akcay @ashwinvaidya17 @rajeshgangireddy
 /third-party-programs.txt                                   @samet-akcay @ashwinvaidya17 @rajeshgangireddy
 /tox.ini                                                    @samet-akcay @ashwinvaidya17 @rajeshgangireddy
+/uv.lock                                                    @samet-akcay @ashwinvaidya17 @rajeshgangireddy @sys-geti
 
 # Tools
 /tools/experimental                                         @ashwinvaidya17

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,10 +19,25 @@
   // regenerate lock weekly https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
   lockFileMaintenance: {
     enabled: true,
-    schedule: ["* * * * 0"], // weekly
+    schedule: ["* * * * 0"], // weekly on Sunday
+    automerge: true,
+    automergeType: "pr",
+    reviewers: ["sys-geti"],
+    platformAutomerge: true,
+
+    // Renovate does not assign reviewers and assignees to
+    // automerge-enabled PR unless it fails status checks.
+    // With this setting Renovate will instead assign reviewers and
+    // assignees for automerging PRs at time of creation.
+    assignAutomerge: true,
   },
 
-  extends: ["config:base", ":gitSignOff", "helpers:pinGitHubActionDigests"],
+  extends: [
+    "config:base",
+    ":gitSignOff",
+    "helpers:pinGitHubActionDigests",
+    ":semanticCommits",
+  ],
   // https://docs.renovatebot.com/presets-default/#gitsignoff
   // https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests
 
@@ -31,7 +46,14 @@
   // `matchBaseBranches` in specific rule
   baseBranches: ["main"],
 
-  enabledManagers: ["github-actions", "pep621", "dockerfile", "npm", "cargo"],
+  enabledManagers: [
+    "github-actions",
+    "pep621",
+    "dockerfile",
+    "npm",
+    "cargo",
+    "custom.regex",
+  ],
 
   // ignore Geti components
   ignoreDeps: ["@geti/config", "@geti/ui"],
@@ -49,7 +71,12 @@
       pinDigests: true,
       groupName: "Pin images",
       groupSlug: "pin-images",
-      schedule: ["* * * * 0"], // weekly
+      schedule: ["* * * * 6"], // weekly on Saturday
+      automerge: true,
+      automergeType: "pr",
+      reviewers: ["sys-geti"],
+      platformAutomerge: true,
+      assignAutomerge: true,
     },
 
     // Disable python base image upgrades, except patch and digest pinning
@@ -109,7 +136,7 @@
       enabled: true,
       separateMajorMinor: false,
       groupName: "GitHub Actions",
-      matchManagers: ["github-actions"],
+      matchManagers: ["github-actions", "custom.regex"],
       matchPackagePatterns: ["*"],
       schedule: ["* * 1 * *"], // every month
     },
@@ -136,6 +163,17 @@
       matchDepTypes: ["container"],
       matchDepNames: ["mcr.microsoft.com/playwright"],
       matchUpdateTypes: ["major", "minor", "patch"],
+    },
+  ],
+
+  // Is used to upgrade Renovate version
+  customManagers: [
+    {
+      fileMatch: ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+version: (?<currentValue>.*)",
+        "# renovate: datasource=(?<datasource>.*?)\\s+export RENOVATE_IMAGE=(?<depName>[^:]+):(?<currentValue>[^@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?",
+      ],
     },
   ],
 

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,117 @@
+name: Approve Renovate PR
+
+on:
+  pull_request:
+    types:
+      - review_requested
+
+# No permissions by default, no specific permissions are required for this workflow
+permissions: {}
+
+jobs:
+  pre-approve:
+    # Only run in the upstream repository, not in forks
+    name: Pre-Approve
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.capture_sha.outputs.sha }}
+    if: ${{
+      github.repository_owner == 'open-edge-platform' &&
+      github.repository == github.event.pull_request.head.repo.full_name &&
+      github.event.pull_request.user.login == 'oep-renovate[bot]' &&
+      github.event.requested_reviewer.login == 'sys-geti' &&
+      github.event.sender.login == 'oep-renovate[bot]'
+      }}
+    steps:
+      - name: Capture Commit SHA
+        id: capture_sha
+        run: |
+          echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          echo "Captured commit SHA: ${{ github.event.pull_request.head.sha }}"
+
+      - name: Debug
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REQUESTED_REVIEWER: ${{ github.event.requested_reviewer.login }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "PR Author: $PR_AUTHOR"
+          echo "Requested Reviewer: $REQUESTED_REVIEWER"
+          echo "Review Requested By (sender): $SENDER_LOGIN"
+          echo "PR Head SHA: $PR_HEAD_SHA"
+
+  approve:
+    name: Approve
+    needs: pre-approve
+    environment:
+      name: auto-approve
+      deployment: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REQUESTED_REVIEWER: ${{ github.event.requested_reviewer.login }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          ORIGINAL_COMMIT_SHA: ${{ needs.pre-approve.outputs.commit_sha }}
+        run: |
+          echo "PR Author: $PR_AUTHOR"
+          echo "Requested Reviewer: $REQUESTED_REVIEWER"
+          echo "Review Requested By (sender): $SENDER_LOGIN"
+          echo "Original Commit SHA: $ORIGINAL_COMMIT_SHA"
+
+      - name: Validate and Approve PR
+        # Approve the PR if all the following conditions are true:
+        # - running in open-edge-platform repository (not a fork)
+        # - the PR is not from a fork (same repository)
+        # - the PR was created by oep-renovate[bot]
+        # - review was requested from sys-geti
+        # - review was requested by oep-renovate[bot]
+        if: ${{
+          github.repository_owner == 'open-edge-platform' &&
+          github.repository == github.event.pull_request.head.repo.full_name &&
+          github.event.pull_request.user.login == 'oep-renovate[bot]' &&
+          github.event.requested_reviewer.login == 'sys-geti' &&
+          github.event.sender.login == 'oep-renovate[bot]'
+          }}
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          ORIGINAL_SHA: ${{ needs.pre-approve.outputs.commit_sha }}
+        run: |
+          # Defense-in-depth: re-validate PR state at approval time
+          echo "Verifying PR author..."
+          pr_author=$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}" --jq '.user.login')
+
+          if [ "$pr_author" != "oep-renovate[bot]" ]; then
+            echo "Error: PR author is not oep-renovate[bot], actual: ${pr_author}"
+            exit 1
+          fi
+
+          echo "Verifying sys-geti is a requested reviewer..."
+          is_reviewer=$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}" --jq '[.requested_reviewers[].login] | contains(["sys-geti"])')
+
+          if [ "$is_reviewer" != "true" ]; then
+            echo "Error: sys-geti is not a requested reviewer"
+            exit 1
+          fi
+
+          # Verify commit SHA has not changed (no new commits added)
+          echo "Verifying commit SHA has not changed..."
+          current_sha=$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+
+          if [ "$current_sha" != "$ORIGINAL_SHA" ]; then
+            echo "Error: PR has been modified since review request"
+            echo "Original SHA: ${ORIGINAL_SHA}"
+            echo "Current SHA:  ${current_sha}"
+            exit 1
+          fi
+
+          echo "Commit SHA verified: ${current_sha}"
+
+          echo "All security checks passed. Approving PR #${PR_NUMBER}..."
+          gh pr review "${PR_NUMBER}" \
+            --repo "${REPO}" \
+            --approve

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Validate configuration
         run: |
           # renovate: datasource=docker
-          export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:40.11
+          export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:43.86.0@sha256:a09b54d017aa7bd24b61a6d79f78fac6ebc651fb6c0cabaedd22915690c854c6
           docker run --rm --entrypoint "renovate-config-validator" \
           -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5" \
           ${RENOVATE_IMAGE} "/renovate.json5"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -75,6 +75,8 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@3633cede7d4d4598438e654eac4a695e46004420 # v46.1.7
         with:
+          # renovate: datasource=github-releases depName=renovatebot/renovate
+          renovate-version: 43.86.0
           configurationFile: .github/renovate.json5
           token: "${{ steps.get-github-app-token.outputs.token }}"
         env:


### PR DESCRIPTION
## 📝 Description

This PR introduces an auto-approval flow for Renovate PRs that are mostly safe to merge without human intervention if CI is green (container images sha updates and lock files refresh).
Proposed flow respects existing branch protection rules and Renovate PR will be merged only if all branch protection rules requirements including required checks are met.
A separate system account is used to approve PRs created by the oep-renovate bot, as it is currently not possible to use a bot in `CODEOWNERS` (GitHub [limitation](https://github.com/orgs/community/discussions/23064)).

## ✨ Changes

Select what type of change your PR is:

- [x] 🚧 CI/CD configuration

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
