### PR TITLE
fix(tauri): open feedback issue link in system browser using shell plugin (#3425)

### DIFF
--- a/application/binary/tauri/src-tauri/capabilities/default.json
+++ b/application/binary/tauri/src-tauri/capabilities/default.json
@@ -13,6 +13,12 @@
     "dialog:allow-ask",
     "dialog:allow-save",
     "fs:default",
-    "fs:allow-write-file"
+    "fs:allow-write-file",
+    {
+      "identifier": "shell:allow-open",
+      "allow": [
+        { "url": "https://github.com/**" }
+      ]
+    }
   ]
 }

--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -19,6 +19,7 @@
                 "@tauri-apps/api": "^2",
                 "@tauri-apps/plugin-dialog": "^2",
                 "@tauri-apps/plugin-fs": "^2",
+                "@tauri-apps/plugin-shell": "^2",
                 "clsx": "^2.1.1",
                 "comlink": "^4.4.2",
                 "lodash-es": "^4.18.1",
@@ -8621,7 +8622,9 @@
             }
         },
         "node_modules/@tauri-apps/api": {
-            "version": "2.9.1",
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+            "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
             "license": "Apache-2.0 OR MIT",
             "funding": {
                 "type": "opencollective",
@@ -8640,6 +8643,15 @@
             "license": "MIT OR Apache-2.0",
             "dependencies": {
                 "@tauri-apps/api": "^2.8.0"
+            }
+        },
+        "node_modules/@tauri-apps/plugin-shell": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
+            "integrity": "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==",
+            "license": "MIT OR Apache-2.0",
+            "dependencies": {
+                "@tauri-apps/api": "^2.10.1"
             }
         },
         "node_modules/@testing-library/dom": {

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -36,6 +36,7 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-fs": "^2",
+        "@tauri-apps/plugin-shell": "^2",
         "clsx": "^2.1.1",
         "comlink": "^4.4.2",
         "lodash-es": "^4.18.1",

--- a/application/ui/src/features/inspect/feedback/feedback-button.component.tsx
+++ b/application/ui/src/features/inspect/feedback/feedback-button.component.tsx
@@ -4,6 +4,7 @@
 import { useState } from 'react';
 
 import { fetchClient } from '@anomalib-studio/api';
+import { isTauri } from '@tauri-apps/api/core';
 import {
     ActionButton,
     Button,
@@ -177,10 +178,27 @@ interface SubmitFeedbackParams {
     description: string;
 }
 
+/**
+ * Opens the GitHub issue URL in the user's default browser.
+ * In Tauri, window.open() is silently blocked by the webview, so we use the
+ * shell plugin to launch the URL externally. Falls back to window.open() if
+ * the shell plugin is unavailable or in a regular browser environment.
+ * @see https://github.com/open-edge-platform/anomalib/issues/3425
+ */
 const submitFeedback = async ({ issueType, description }: SubmitFeedbackParams): Promise<void> => {
     const systemInfo = await fetchSystemInfo();
     const issueUrl = createGitHubIssueUrl(systemInfo, issueType, description);
-    window.open(issueUrl, '_blank', 'noopener,noreferrer');
+    if (isTauri()) {
+        try {
+            const { open } = await import('@tauri-apps/plugin-shell');
+            await open(issueUrl);
+        } catch {
+            // Fallback to browser API if shell plugin fails
+            window.open(issueUrl, '_blank', 'noopener,noreferrer');
+        }
+    } else {
+        window.open(issueUrl, '_blank', 'noopener,noreferrer');
+    }
 };
 
 interface FeedbackDialogContentProps {

--- a/application/ui/src/features/inspect/feedback/feedback-button.component.tsx
+++ b/application/ui/src/features/inspect/feedback/feedback-button.component.tsx
@@ -4,7 +4,6 @@
 import { useState } from 'react';
 
 import { fetchClient } from '@anomalib-studio/api';
-import { isTauri } from '@tauri-apps/api/core';
 import {
     ActionButton,
     Button,
@@ -25,6 +24,7 @@ import {
 } from '@geti/ui';
 import { CheckmarkCircleOutline, DownloadIcon, ExternalLinkIcon, HelpIcon } from '@geti/ui/icons';
 import { useMutation } from '@tanstack/react-query';
+import { isTauri } from '@tauri-apps/api/core';
 
 import { downloadBlob } from '../utils';
 


### PR DESCRIPTION
## Description

Fixes an issue in the Tauri desktop app where clicking "Open GitHub Issue" in the Submit Feedback dialog does nothing.

Issue: #3425

In the current behavior, when a user clicks the submit button, no browser opens and no error is shown. The dialog simply closes, making it look like the action succeeded even though nothing actually happened.

From the issue:
- Platform: Tauri desktop app (Windows)
- Expected: GitHub issue page should open in the default browser
- Actual: Nothing happens on click

The root cause is that `window.open()` is silently blocked inside Tauri’s webview. It does not throw an error and returns `null`, so the async function resolves successfully. Because of this, the success callback is triggered and the dialog closes, creating a misleading UX.

## Root Cause

This issue was caused by three things:

1. `window.open()` silently fails in Tauri (returns null, no error)
2. `@tauri-apps/plugin-shell` was not added to the UI dependencies
3. Missing `shell:allow-open` permission in Tauri capabilities

## Fix

- Detect Tauri environment using `isTauri()`
- Use `@tauri-apps/plugin-shell` `open()` to launch the URL in the system browser
- Fall back to `window.open()` for non-Tauri environments
- Add `@tauri-apps/plugin-shell` to `application/ui/package.json`
- Add `shell:allow-open` permission scoped to `https://github.com/**`

No Rust changes were needed since the plugin was already registered.

This follows the same pattern already used in the codebase for file download handling.

## Proof

Loom (working demo): [https://www.loom.com/share/2c7265c2f7a247e7b2bf5e36039dc938](https://www.loom.com/share/2c7265c2f7a247e7b2bf5e36039dc938)

## Changes

- [x] Bug fix

## Checklist

- [x] Code follows project conventions
- [x] Fix is tested manually
- [x] PR title follows conventional commit format