### PR TITLE
fix(ci): add opencode path to workflow

### DIFF
--- a/.github/actions/ollama-preflight/action.yaml
+++ b/.github/actions/ollama-preflight/action.yaml
@@ -17,6 +17,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Add OpenCode CLI to PATH
+      shell: bash
+      run: |
+        echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+
     - name: Verify required binaries
       shell: bash
       run: |

--- a/.github/actions/ollama-preflight/action.yaml
+++ b/.github/actions/ollama-preflight/action.yaml
@@ -25,7 +25,7 @@ runs:
     - name: Verify required binaries
       shell: bash
       run: |
-        for cmd in ollama opencode gh curl jq; do
+        for cmd in ollama opencode gh curl; do
           command -v "$cmd" >/dev/null 2>&1 || { echo "::error::$cmd is not installed on this runner"; exit 1; }
         done
 
@@ -39,7 +39,7 @@ runs:
           echo "::error::Ollama is not running at ${OLLAMA_HOST}"
           exit 1
         fi
-        AVAILABLE=$(curl -sf "${OLLAMA_HOST}/api/tags" | jq -r '.models[].name // empty')
+        AVAILABLE=$(ollama list | awk 'NR > 1 {print $1}')
         for MODEL in $MODELS; do
           if ! echo "$AVAILABLE" | grep -qxF "$MODEL"; then
             echo "::warning::$MODEL not found, pulling..."

--- a/.github/agents/agents-md-sync-opencode.md
+++ b/.github/agents/agents-md-sync-opencode.md
@@ -30,7 +30,7 @@ If ALL changes are "No structural impact", stop. Output: "No structural changes.
 
 ## Step 3 — Update AGENTS.md
 
-If `AGENTS.md` exists, edit only within `<!-- BEGIN MANAGED SECTION -->` / `<!-- END MANAGED SECTION -->` markers.
+If `AGENTS.md` exists, refresh the file with the current state of the repository.
 
 If it doesn't exist, create it with the standard skeleton (architecture map, conventions, API surface, models list, CI section, agent config files table).
 

--- a/.github/agents/agents-md-sync-opencode.md
+++ b/.github/agents/agents-md-sync-opencode.md
@@ -51,7 +51,6 @@ gh pr create --title "docs: update AGENTS.md with recent codebase changes" \
 ## Rules
 
 - **Only edit `AGENTS.md`.** Never modify source code.
-- **Respect managed-section markers.** Content outside them is hand-maintained.
 - **Be factual.** Derive info from actual files. Do not hallucinate.
 - **Keep concise.** One-liners per module, link to details.
 - **Idempotent.** If already accurate, do not open a PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md
 
-<!-- BEGIN MANAGED SECTION -->
 ## Setup commands
 
-- Manage python environment with uv
-<!-- END MANAGED SECTION -->
+- Manage the Python environment with `uv`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+<!-- BEGIN MANAGED SECTION -->
 ## Setup commands
 
 - Manage python environment with uv
+<!-- END MANAGED SECTION -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+## Setup commands
+
+- Manage python environment with uv


### PR DESCRIPTION
## 📝 Description

- GH actions runner inside docker internally uses `shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}`. This leads to missing opencode path.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
