### PR TITLE
chore(ci): apply path filter to CI library checks

### DIFF
--- a/.github/actions/ollama-preflight/action.yaml
+++ b/.github/actions/ollama-preflight/action.yaml
@@ -19,7 +19,8 @@ runs:
   steps:
     - name: Add OpenCode CLI to PATH
       shell: bash
-      run: |
+      # Path is hardcoded to the standard OpenCode install location
+      run: | # zizmor: ignore[github-env]
         echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
     - name: Verify required binaries

--- a/.github/workflows/_reusable-artifact-builder.yaml
+++ b/.github/workflows/_reusable-artifact-builder.yaml
@@ -69,12 +69,13 @@ on:
         description: "Name of the uploaded artifact"
         value: ${{ jobs.build.outputs.artifact-name }}
 
-permissions:
-  contents: read
+permissions: {} # No permissions by default on workflow level
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required to checkout the repository
     outputs:
       artifact-name: ${{ steps.set-artifact-name.outputs.name }}
     steps:

--- a/.github/workflows/_reusable-artifact-builder.yaml
+++ b/.github/workflows/_reusable-artifact-builder.yaml
@@ -75,7 +75,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read  # Required to checkout the repository
+      contents: read # Required to checkout the repository
     outputs:
       artifact-name: ${{ steps.set-artifact-name.outputs.name }}
     steps:

--- a/.github/workflows/_reusable-code-quality.yaml
+++ b/.github/workflows/_reusable-code-quality.yaml
@@ -56,13 +56,14 @@ on:
         type: string
         default: "3.10"
 
-permissions:
-  contents: read
+permissions: {} # No permissions by default on workflow level
 
 jobs:
   prek:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read  # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/_reusable-code-quality.yaml
+++ b/.github/workflows/_reusable-code-quality.yaml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read  # Required to checkout the repository
+      contents: read # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/_reusable-docker-build.yaml
+++ b/.github/workflows/_reusable-docker-build.yaml
@@ -186,8 +186,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
-      # write permissions are required to update PR comments with image sizes
-      pull-requests: write
+      pull-requests: write # write permissions are required to update PR comments with image sizes
     continue-on-error: true
     steps:
       - name: Harden the runner (audit all outbound calls)

--- a/.github/workflows/_reusable-pr-title-check.yaml
+++ b/.github/workflows/_reusable-pr-title-check.yaml
@@ -51,13 +51,14 @@ on:
         type: string
         default: "3.10"
 
-permissions:
-  contents: read
+permissions: {} # No permissions by default on workflow level
 
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read  # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/_reusable-pr-title-check.yaml
+++ b/.github/workflows/_reusable-pr-title-check.yaml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read  # Required to checkout the repository
+      contents: read # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/_reusable-test-suite.yaml
+++ b/.github/workflows/_reusable-test-suite.yaml
@@ -101,7 +101,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout }}
     permissions:
-      contents: read  # Required to checkout the repository
+      contents: read # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         if: "!contains(inputs.runner, 'self-hosted')"

--- a/.github/workflows/_reusable-test-suite.yaml
+++ b/.github/workflows/_reusable-test-suite.yaml
@@ -94,13 +94,14 @@ on:
         description: "Path to test results artifact"
         value: ${{ jobs.test.outputs.artifact-path }}
 
-permissions:
-  contents: read
+permissions: {} # No permissions by default on workflow level
 
 jobs:
   test:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout }}
+    permissions:
+      contents: read  # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         if: "!contains(inputs.runner, 'self-hosted')"

--- a/.github/workflows/_reusable-version-bump.yaml
+++ b/.github/workflows/_reusable-version-bump.yaml
@@ -98,8 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write       # Required to commit version bump changes (pyproject.toml, CHANGELOG.md)
-      pull-requests: write  # Required to create the automated version bump PR
+      contents: write # Required to commit version bump changes (pyproject.toml, CHANGELOG.md)
+      pull-requests: write # Required to create the automated version bump PR
     outputs:
       new-version: ${{ steps.bump.outputs.new_version }}
       version-changed: ${{ steps.bump.outputs.version_changed }}

--- a/.github/workflows/_reusable-version-bump.yaml
+++ b/.github/workflows/_reusable-version-bump.yaml
@@ -91,16 +91,15 @@ on:
         description: "Whether the version was changed"
         value: ${{ jobs.bump-version.outputs.version-changed }}
 
-permissions:
-  contents: read
+permissions: {} # No permissions by default on workflow level
 
 jobs:
   bump-version:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write       # Required to commit version bump changes (pyproject.toml, CHANGELOG.md)
+      pull-requests: write  # Required to create the automated version bump PR
     outputs:
       new-version: ${{ steps.bump.outputs.new_version }}
       version-changed: ${{ steps.bump.outputs.version_changed }}

--- a/.github/workflows/_reusable-version-check.yaml
+++ b/.github/workflows/_reusable-version-check.yaml
@@ -73,12 +73,13 @@ on:
         description: "Whether version is a pre-release"
         value: ${{ jobs.validate.outputs.is_prerelease }}
 
-permissions:
-  contents: read
+permissions: {} # No permissions by default on workflow level
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required to checkout the repository for git tag reading
     outputs:
       version: ${{ steps.get-version.outputs.version }}
       is_prerelease: ${{ steps.check-prerelease.outputs.is_prerelease }}

--- a/.github/workflows/_reusable-version-check.yaml
+++ b/.github/workflows/_reusable-version-check.yaml
@@ -79,7 +79,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     permissions:
-      contents: read  # Required to checkout the repository for git tag reading
+      contents: read # Required to checkout the repository for git tag reading
     outputs:
       version: ${{ steps.get-version.outputs.version }}
       is_prerelease: ${{ steps.check-prerelease.outputs.is_prerelease }}

--- a/.github/workflows/anomalib-studio.yaml
+++ b/.github/workflows/anomalib-studio.yaml
@@ -1,6 +1,10 @@
 name: Anomalib Studio UI checks
 permissions: {} # No permissions by default on workflow level
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]
@@ -12,13 +16,35 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-    paths:
-      - "application/**"
   workflow_dispatch: # run on request (no need for PR)
 
 jobs:
+  check-paths:
+    name: Check if workflow should run
+    runs-on: ubuntu-latest
+    outputs:
+      run_workflow: ${{ steps.check_paths.outputs.run }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Check paths
+        id: check_paths
+        uses: open-edge-platform/geti-ci/actions/check-paths@7e686c1248b3939f8ee8e04e2612da727e379d91
+        with:
+          files_yaml: |
+            test:
+              - application/**
+              - .github/workflows/anomalib-studio.yaml
+
   generate-openapi-spec:
     name: Generate OpenAPI Spec
+    needs: check-paths
+    if: needs.check-paths.outputs.run_workflow == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read # to checkout code
@@ -69,6 +95,8 @@ jobs:
           path: application/backend/openapi-spec.json
 
   python-checks:
+    needs: check-paths
+    if: needs.check-paths.outputs.run_workflow == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read # to checkout code
@@ -121,7 +149,9 @@ jobs:
   ui-build:
     name: Build UI
     needs:
+      - check-paths
       - generate-openapi-spec
+    if: needs.check-paths.outputs.run_workflow == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read # to checkout code
@@ -171,7 +201,9 @@ jobs:
   ui-lint:
     name: Eslint checks
     needs:
+      - check-paths
       - generate-openapi-spec
+    if: needs.check-paths.outputs.run_workflow == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read # to checkout code
@@ -228,7 +260,9 @@ jobs:
   ui-unit-tests:
     name: Unit tests
     needs:
+      - check-paths
       - generate-openapi-spec
+    if: needs.check-paths.outputs.run_workflow == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read # to checkout code
@@ -273,8 +307,10 @@ jobs:
   ui-playwright-tests:
     name: Playwright Tests
     needs:
+      - check-paths
       - ui-build
       - generate-openapi-spec
+    if: needs.check-paths.outputs.run_workflow == 'true'
     permissions:
       contents: read # to checkout code
     timeout-minutes: 60
@@ -333,3 +369,28 @@ jobs:
           name: playwright-report
           path: application/ui/playwright-report/
           retention-days: 30
+
+  required-check:
+    name: Required Check anomalib-studio
+    needs:
+      - check-paths
+      - generate-openapi-spec
+      - python-checks
+      - ui-build
+      - ui-lint
+      - ui-unit-tests
+      - ui-playwright-tests
+    runs-on: ubuntu-latest
+    env:
+      CHECKS: ${{ join(needs.*.result, ' ') }}
+    if: always() && !cancelled()
+    steps:
+      - name: Check jobs results
+        run: |
+          for check in ${CHECKS}; do
+            echo "::notice::check=${check}"
+            if [[ "$check" != "success" && "$check" != "skipped" ]]; then
+              echo "::error ::Required status checks failed. They must succeed before this pull request can be merged."
+              exit 1
+            fi
+          done

--- a/.github/workflows/anomalib-studio.yaml
+++ b/.github/workflows/anomalib-studio.yaml
@@ -27,6 +27,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -318,6 +323,11 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-jammy@sha256:6aca677c27a967caf7673d108ac67ffaf8fed134f27e17b27a05464ca0ace831
     steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Install git lfs
         run: apt-get update && apt-get install git-lfs
 
@@ -385,12 +395,17 @@ jobs:
       CHECKS: ${{ join(needs.*.result, ' ') }}
     if: always() && !cancelled()
     steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Check jobs results
         run: |
           for check in ${CHECKS}; do
             echo "::notice::check=${check}"
             if [[ "$check" != "success" && "$check" != "skipped" ]]; then
-              echo "::error ::Required status checks failed. They must succeed before this pull request can be merged."
+              echo "::error::Required status checks failed. They must succeed before this pull request can be merged."
               exit 1
             fi
           done

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+permissions: {} # No permissions by default on workflow level
+
 jobs:
   # The job MUST be called 'copilot-setup-steps' to be recognized by GitHub Copilot Agent
   copilot-setup-steps:

--- a/.github/workflows/dco_merge_group.yml
+++ b/.github/workflows/dco_merge_group.yml
@@ -6,12 +6,13 @@ name: DCO
 on:
   merge_group:
 
-permissions: # set top-level default permissions as security best practice
-  contents: read # Check https://github.com/ossf/scorecard/blob/7ce8609469289d5f3b1bf5ee3122f42b4e3054fb/docs/checks.md#token-permissions
+permissions: {} # No permissions by default on workflow level
 
 jobs:
   DCO:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Harden the runner (audit all outbound calls)

--- a/.github/workflows/issue-management.yaml
+++ b/.github/workflows/issue-management.yaml
@@ -50,7 +50,7 @@ jobs:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write  # Required to post a triage comment on the issue
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -72,8 +72,8 @@ jobs:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write          # Required to mark issues as stale and close them
+      pull-requests: write   # Required to mark pull requests as stale and close them
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/issue-management.yaml
+++ b/.github/workflows/issue-management.yaml
@@ -50,7 +50,7 @@ jobs:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     permissions:
-      issues: write  # Required to post a triage comment on the issue
+      issues: write # Required to post a triage comment on the issue
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -72,8 +72,8 @@ jobs:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
-      issues: write          # Required to mark issues as stale and close them
-      pull-requests: write   # Required to mark pull requests as stale and close them
+      issues: write # Required to mark issues as stale and close them
+      pull-requests: write # Required to mark pull requests as stale and close them
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -57,11 +57,32 @@ jobs:
         continue-on-error: true
         run: npm audit fix --force || true
 
+      - name: Install dependencies (tauri)
+        working-directory: application/binary/tauri
+        run: npm ci
+
+      - name: Display audit report (tauri)
+        working-directory: application/binary/tauri
+        continue-on-error: true
+        run: |
+          npm audit || true
+
+      - name: Run npm audit fix - safe mode (tauri)
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.force_fix != 'true' }}
+        working-directory: application/binary/tauri
+        continue-on-error: true
+        run: npm audit fix --package-lock-only || echo "Some issues could not be auto-fixed"
+
+      - name: Run npm audit fix - force mode (tauri)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_fix == 'true' }}
+        working-directory: application/binary/tauri
+        continue-on-error: true
+        run: npm audit fix --force || true
+
       - name: Check for changes
         id: check-changes
-        working-directory: application/ui
         run: |
-          if git diff --quiet package-lock.json package.json; then
+          if git diff --quiet application/ui/package-lock.json application/ui/package.json application/binary/tauri/package-lock.json application/binary/tauri/package.json; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else
             echo "changed=true" >> $GITHUB_OUTPUT
@@ -94,3 +115,5 @@ jobs:
           add-paths: |
             application/ui/package-lock.json
             application/ui/package.json
+            application/binary/tauri/package-lock.json
+            application/binary/tauri/package.json

--- a/.github/workflows/opencode-agents-md-sync.yml
+++ b/.github/workflows/opencode-agents-md-sync.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 45
     permissions:
-      contents: write       # Required to commit and push AGENTS.md updates
-      pull-requests: write  # Required to create the agents-md-sync PR
+      contents: write # Required to commit and push AGENTS.md updates
+      pull-requests: write # Required to create the agents-md-sync PR
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/opencode-agents-md-sync.yml
+++ b/.github/workflows/opencode-agents-md-sync.yml
@@ -8,9 +8,7 @@ on:
     - cron: "0 8 * * 1" # Weekly on Monday at 8:00 UTC
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {} # No permissions by default on workflow level
 
 concurrency:
   group: "opencode-agents-md-sync"
@@ -20,6 +18,9 @@ jobs:
   agents-md-sync:
     runs-on: self-hosted
     timeout-minutes: 45
+    permissions:
+      contents: write       # Required to commit and push AGENTS.md updates
+      pull-requests: write  # Required to create the agents-md-sync PR
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/opencode-docs-sync.yml
+++ b/.github/workflows/opencode-docs-sync.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 45
     permissions:
-      contents: write       # Required to commit and push documentation updates
-      pull-requests: write  # Required to create the docs-sync PR
+      contents: write # Required to commit and push documentation updates
+      pull-requests: write # Required to create the docs-sync PR
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/opencode-docs-sync.yml
+++ b/.github/workflows/opencode-docs-sync.yml
@@ -8,9 +8,7 @@ on:
     - cron: "30 9 * * 1-5" # Weekdays at 9:30 UTC
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {} # No permissions by default on workflow level
 
 concurrency:
   group: "opencode-docs-sync"
@@ -20,6 +18,9 @@ jobs:
   docs-sync:
     runs-on: self-hosted
     timeout-minutes: 45
+    permissions:
+      contents: write       # Required to commit and push documentation updates
+      pull-requests: write  # Required to create the docs-sync PR
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/opencode-issue-triage.yml
+++ b/.github/workflows/opencode-issue-triage.yml
@@ -14,9 +14,13 @@ concurrency:
 
 jobs:
   triage:
-    # Skip issues from users with no GitHub association (spam protection)
+    # Allow only trusted associations: OWNER, MEMBER, COLLABORATOR.
+    # CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / FIRST_TIMER / NONE are excluded
+    # because any GitHub user can reach those tiers and trigger this agent on
+    # a self-hosted runner via a crafted issue body (prompt injection).
     if: >-
-      github.event.issue.author_association != 'NONE'
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'),
+               github.event.issue.author_association)
     runs-on: self-hosted
     timeout-minutes: 20
     permissions:
@@ -39,7 +43,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          OPENCODE_PERMISSION: '{"read":"allow","glob":"allow","grep":"allow","bash":{"*":"deny","gh issue *":"allow","gh search *":"allow","gh label *":"allow","gh api *":"allow","cat *":"allow","find *":"allow","grep *":"allow","head *":"allow"},"edit":"deny"}'
+          OPENCODE_PERMISSION: '{"read":"allow","glob":"allow","grep":"allow","bash":{"*":"deny","gh issue *":"allow","gh search *":"allow","gh label *":"allow","gh api *":"allow"},"edit":"deny"}'
           OPENCODE_CONFIG: .github/opencode.json
         run: |
           opencode run --pure -m ollama/gemma4:31b --agent issue-triage \

--- a/.github/workflows/opencode-issue-triage.yml
+++ b/.github/workflows/opencode-issue-triage.yml
@@ -7,9 +7,7 @@ on:
   issues:
     types: [opened]
 
-permissions:
-  contents: read
-  issues: write
+permissions: {} # No permissions by default on workflow level
 
 concurrency:
   group: "opencode-issue-triage-${{ github.event.issue.number }}"
@@ -21,6 +19,9 @@ jobs:
       github.event.issue.author_association != 'NONE'
     runs-on: self-hosted
     timeout-minutes: 20
+    permissions:
+      contents: read  # Required to checkout the repository
+      issues: write   # Required to label and comment on issues
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/opencode-issue-triage.yml
+++ b/.github/workflows/opencode-issue-triage.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 20
     permissions:
-      contents: read  # Required to checkout the repository
-      issues: write   # Required to label and comment on issues
+      contents: read # Required to checkout the repository
+      issues: write # Required to label and comment on issues
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Check paths
         id: check-library-paths
-        uses: open-edge-platform/geti-ci/actions/check-paths@7d25e47329bbfcde4ee51ab3581aea8613e245e2
+        uses: open-edge-platform/geti-ci/actions/check-paths@7e686c1248b3939f8ee8e04e2612da727e379d91
         with:
           files_yaml: |
             test:
@@ -194,7 +194,7 @@ jobs:
 
       - name: Check paths
         id: check-paths
-        uses: open-edge-platform/geti-ci/actions/check-paths@7d25e47329bbfcde4ee51ab3581aea8613e245e2
+        uses: open-edge-platform/geti-ci/actions/check-paths@7e686c1248b3939f8ee8e04e2612da727e379d91
         with:
           files_yaml: |
             test:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,8 +63,7 @@ on:
   merge_group:
     branches: [main]
 
-permissions:
-  contents: read
+permissions: {} # No permissions by default on workflow level
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -77,6 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_library: ${{ steps.check-library-paths.outputs.run }}
+    permissions:
+      contents: read  # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -109,6 +110,8 @@ jobs:
   pr-title-check:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/_reusable-pr-title-check.yaml
+    permissions:
+      contents: read  # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
 
@@ -117,6 +120,8 @@ jobs:
     needs: check-library-paths
     if: needs.check-library-paths.outputs.run_library == 'true' && github.event.pull_request.draft != true
     uses: ./.github/workflows/_reusable-code-quality.yaml
+    permissions:
+      contents: read  # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
 
@@ -125,6 +130,8 @@ jobs:
     needs: check-library-paths
     if: needs.check-library-paths.outputs.run_library == 'true' && github.event.pull_request.draft != true
     uses: ./.github/workflows/_reusable-test-suite.yaml
+    permissions:
+      contents: read  # Required by the called workflow to checkout the repository
     with:
       test-type: "unit"
       runner: "ubuntu-latest"
@@ -137,6 +144,8 @@ jobs:
     needs: check-library-paths
     if: needs.check-library-paths.outputs.run_library == 'true' && github.event.pull_request.draft != true
     uses: ./.github/workflows/_reusable-test-suite.yaml
+    permissions:
+      contents: read  # Required by the called workflow to checkout the repository
     with:
       test-type: "integration"
       runner: "self-hosted"
@@ -170,6 +179,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_build: ${{ steps.check-paths.outputs.run }}
+    permissions:
+      contents: read  # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -103,6 +103,7 @@ jobs:
               - uv.lock
               - .pre-commit-config.yaml
               - tox.ini
+              - .github/actions/pytest/**
               - .github/workflows/pr.yaml
               - .github/workflows/_reusable-code-quality.yaml
               - .github/workflows/_reusable-test-suite.yaml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -100,6 +100,8 @@ jobs:
               - examples/**
               - tools/**
               - pyproject.toml
+              - uv.lock
+              - .pre-commit-config.yaml
               - tox.ini
               - .github/workflows/pr.yaml
               - .github/workflows/_reusable-code-quality.yaml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -71,6 +71,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Determines if library checks (quality, unit/integration tests) should run
+  check-library-paths:
+    name: Check if library checks should run
+    runs-on: ubuntu-latest
+    outputs:
+      run_library: ${{ steps.check-library-paths.outputs.run }}
+    steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Check paths
+        id: check-library-paths
+        uses: open-edge-platform/geti-ci/actions/check-paths@7d25e47329bbfcde4ee51ab3581aea8613e245e2
+        with:
+          files_yaml: |
+            test:
+              - src/**
+              - tests/**
+              - examples/**
+              - tools/**
+              - pyproject.toml
+              - tox.ini
+              - .github/workflows/pr.yaml
+              - .github/workflows/_reusable-code-quality.yaml
+              - .github/workflows/_reusable-test-suite.yaml
+
   # PR title validation - runs first as it's quick and fundamental
   # Only runs on actual pull requests, not merge groups
   pr-title-check:
@@ -81,14 +114,16 @@ jobs:
 
   # Code quality job using reusable workflow
   quality:
-    if: github.event.pull_request.draft != true
+    needs: check-library-paths
+    if: needs.check-library-paths.outputs.run_library == 'true' && github.event.pull_request.draft != true
     uses: ./.github/workflows/_reusable-code-quality.yaml
     with:
       python-version: "3.10"
 
   # Test suite job using reusable workflow
   unit-tests:
-    if: github.event.pull_request.draft != true
+    needs: check-library-paths
+    if: needs.check-library-paths.outputs.run_library == 'true' && github.event.pull_request.draft != true
     uses: ./.github/workflows/_reusable-test-suite.yaml
     with:
       test-type: "unit"
@@ -99,7 +134,8 @@ jobs:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   integration-tests:
-    if: github.event.pull_request.draft != true
+    needs: check-library-paths
+    if: needs.check-library-paths.outputs.run_library == 'true' && github.event.pull_request.draft != true
     uses: ./.github/workflows/_reusable-test-suite.yaml
     with:
       test-type: "integration"
@@ -186,6 +222,33 @@ jobs:
             echo "::notice::check=${check}"
             if [[ "$check" != "success" && "$check" != "skipped" ]]; then
               echo "::error::Build docker image status checks failed. They must succeed before this pull request can be merged."
+              exit 1
+            fi
+          done
+
+  library-checks-status:
+    name: Library checks status
+    needs:
+      - check-library-paths
+      - quality
+      - unit-tests
+      - integration-tests
+    runs-on: ubuntu-latest
+    env:
+      CHECKS: ${{ join(needs.*.result, ' ') }}
+    if: always() && !cancelled()
+    steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check jobs results
+        run: |
+          for check in ${CHECKS}; do
+            echo "::notice::check=${check}"
+            if [[ "$check" != "success" && "$check" != "skipped" ]]; then
+              echo "::error::Library checks failed. They must succeed before this pull request can be merged."
               exit 1
             fi
           done

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -77,7 +77,7 @@ jobs:
     outputs:
       run_library: ${{ steps.check-library-paths.outputs.run }}
     permissions:
-      contents: read  # Required to checkout the repository
+      contents: read # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -111,7 +111,7 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/_reusable-pr-title-check.yaml
     permissions:
-      contents: read  # Required by the called workflow to checkout the repository
+      contents: read # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
 
@@ -121,7 +121,7 @@ jobs:
     if: needs.check-library-paths.outputs.run_library == 'true' && github.event.pull_request.draft != true
     uses: ./.github/workflows/_reusable-code-quality.yaml
     permissions:
-      contents: read  # Required by the called workflow to checkout the repository
+      contents: read # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
 
@@ -131,7 +131,7 @@ jobs:
     if: needs.check-library-paths.outputs.run_library == 'true' && github.event.pull_request.draft != true
     uses: ./.github/workflows/_reusable-test-suite.yaml
     permissions:
-      contents: read  # Required by the called workflow to checkout the repository
+      contents: read # Required by the called workflow to checkout the repository
     with:
       test-type: "unit"
       runner: "ubuntu-latest"
@@ -145,7 +145,7 @@ jobs:
     if: needs.check-library-paths.outputs.run_library == 'true' && github.event.pull_request.draft != true
     uses: ./.github/workflows/_reusable-test-suite.yaml
     permissions:
-      contents: read  # Required by the called workflow to checkout the repository
+      contents: read # Required by the called workflow to checkout the repository
     with:
       test-type: "integration"
       runner: "self-hosted"
@@ -180,7 +180,7 @@ jobs:
     outputs:
       run_build: ${{ steps.check-paths.outputs.run }}
     permissions:
-      contents: read  # Required to checkout the repository
+      contents: read # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -59,7 +59,7 @@ jobs:
     outputs:
       version: ${{ steps.validate-version.outputs.version }}
     permissions:
-      contents: read  # Required to checkout the repository for version validation
+      contents: read # Required to checkout the repository for version validation
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -99,7 +99,7 @@ jobs:
     needs: [version-check]
     uses: ./.github/workflows/_reusable-code-quality.yaml
     permissions:
-      contents: read  # Required by the called workflow to checkout the repository
+      contents: read # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
 
@@ -107,7 +107,7 @@ jobs:
     needs: [version-check]
     uses: ./.github/workflows/_reusable-test-suite.yaml
     permissions:
-      contents: read  # Required by the called workflow to checkout the repository
+      contents: read # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
       test-type: "unit"
@@ -120,7 +120,7 @@ jobs:
     needs: [version-check]
     uses: ./.github/workflows/_reusable-test-suite.yaml
     permissions:
-      contents: read  # Required by the called workflow to checkout the repository
+      contents: read # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
       test-type: "integration"
@@ -133,7 +133,7 @@ jobs:
     needs: [version-check]
     uses: ./.github/workflows/_reusable-security-scan.yaml
     permissions:
-      security-events: write  # Required to upload SARIF scan results to the Security tab
+      security-events: write # Required to upload SARIF scan results to the Security tab
       packages: read
       contents: read
     with:
@@ -149,7 +149,7 @@ jobs:
       !failure() && !cancelled()
     uses: ./.github/workflows/_reusable-artifact-builder.yaml
     permissions:
-      contents: read  # Required by the called workflow to checkout the repository
+      contents: read # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
       verify-package: true

--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -51,14 +51,15 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: read
+permissions: {} # No permissions by default on workflow level
 
 jobs:
   version-check:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.validate-version.outputs.version }}
+    permissions:
+      contents: read  # Required to checkout the repository for version validation
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -97,12 +98,16 @@ jobs:
   quality:
     needs: [version-check]
     uses: ./.github/workflows/_reusable-code-quality.yaml
+    permissions:
+      contents: read  # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
 
   unit-tests:
     needs: [version-check]
     uses: ./.github/workflows/_reusable-test-suite.yaml
+    permissions:
+      contents: read  # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
       test-type: "unit"
@@ -114,6 +119,8 @@ jobs:
   integration-tests:
     needs: [version-check]
     uses: ./.github/workflows/_reusable-test-suite.yaml
+    permissions:
+      contents: read  # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
       test-type: "integration"
@@ -126,7 +133,7 @@ jobs:
     needs: [version-check]
     uses: ./.github/workflows/_reusable-security-scan.yaml
     permissions:
-      security-events: write
+      security-events: write  # Required to upload SARIF scan results to the Security tab
       packages: read
       contents: read
     with:
@@ -141,6 +148,8 @@ jobs:
       !inputs.dry_run &&
       !failure() && !cancelled()
     uses: ./.github/workflows/_reusable-artifact-builder.yaml
+    permissions:
+      contents: read  # Required by the called workflow to checkout the repository
     with:
       python-version: "3.10"
       verify-package: true

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -28,8 +28,7 @@ on:
       - ".github/workflows/renovate.yml"
       - ".github/workflows/renovate-config-validator.yml"
 
-permissions:
-  contents: read
+permissions: {} # No permissions by default on workflow level
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
@@ -38,6 +37,8 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -38,7 +38,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     permissions:
-      contents: read  # Required to checkout the repository
+      contents: read # Required to checkout the repository
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
## 📝 Description

This PR:
- Adds path-filter check jobs and aggregate “status/required-check” jobs to allow skipping expensive checks when unrelated files change (pr.yaml, anomalib-studio.yaml).
- Extend the npm-audit-fix workflow to include the Tauri project lockfile maintenance.
- Set workflow-level `permissions: {}` across multiple workflows/reusable workflows and add explicit job-level permissions where needed.

## ✨ Changes

Select what type of change your PR is:

- [x] 🚧 CI/CD configuration


## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [x] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
