### PR TITLE
Add Pause/Stop inference button to stream view

### DIFF
--- a/application/ui/src/features/inspect/stream/stream.module.scss
+++ b/application/ui/src/features/inspect/stream/stream.module.scss
@@ -56,11 +56,16 @@
     }
 }
 
-.captureButton {
-    color: var(--spectrum-global-color-gray-50) !important;
-    background: var(--spectrum-global-color-gray-900) !important;
+.captureButtonContainer {
+    position: absolute;
+    bottom: var(--spectrum-global-dimension-size-400);
 
-    &:hover {
-        background: rgba(255, 255, 255, 0.8) !important;
+    & > button {
+        color: var(--spectrum-global-color-gray-50) !important;
+        background: var(--spectrum-global-color-gray-900) !important;
+
+        &:hover {
+            background: rgba(255, 255, 255, 0.8) !important;
+        }
     }
 }

--- a/application/ui/src/features/inspect/stream/stream.tsx
+++ b/application/ui/src/features/inspect/stream/stream.tsx
@@ -6,6 +6,7 @@ import { Dispatch, RefObject, SetStateAction, useCallback, useEffect, useRef, us
 import { $api } from '@anomalib-studio/api';
 import { useProjectIdentifier } from '@anomalib-studio/hooks';
 import { Button, dimensionValue, Flex, toast } from '@geti/ui';
+import { Pause } from '@geti/ui/icons';
 import { clsx } from 'clsx';
 
 import { useStreamConnection } from '../../../components/stream/stream-connection-provider';
@@ -70,7 +71,7 @@ const useSetTargetSizeBasedOnImage = (
 export const Stream = () => {
     const imageRef = useRef<HTMLImageElement>(null);
     const { projectId } = useProjectIdentifier();
-    const { setStatus, status, streamUrl } = useStreamConnection();
+    const { setStatus, status, streamUrl, stop } = useStreamConnection();
     const [hasCaptureAnimation, setHasCaptureAnimation] = useState(false);
     const [size, setSize] = useState({ height: 608, width: 892 });
 
@@ -109,6 +110,10 @@ export const Stream = () => {
         });
     };
 
+    const handleStop = async () => {
+        await stop();
+    };
+
     return (
         <Flex
             position={'relative'}
@@ -135,9 +140,15 @@ export const Stream = () => {
                 />
             </ZoomTransform>
             {status === 'connected' && (
-                <Button onPress={handleCaptureFrame} variant='primary' UNSAFE_className={classes.captureButton}>
-                    Capture
-                </Button>
+                <Flex direction={'row'} gap={'size-100'} UNSAFE_className={classes.captureButtonContainer}>
+                    <Button onPress={handleCaptureFrame} variant='primary'>
+                        Capture
+                    </Button>
+                    <Button onPress={handleStop} variant='secondary' aria-label={'Pause stream'}>
+                        <Pause />
+                        Pause
+                    </Button>
+                </Flex>
             )}
         </Flex>
     );


### PR DESCRIPTION


## 📝 Description
Adds a Pause  button alongside the Capture button in the stream view. Clicking Pause stops the stream temporarily by calling `useStreamConnection().stop()`. Wrapped both buttons in a Flex container floating at the bottom to maintain layout consistency.

- 🛠️ Fixes # (issue number)
Closes :#3622 
## ✨ Changes

Select what type of change your PR is:

- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
