### PR TITLE
🐞 fix(data): distribute split remainder over subsets to avoid ZeroDivisionError

### DIFF
--- a/src/anomalib/data/utils/split.py
+++ b/src/anomalib/data/utils/split.py
@@ -165,7 +165,7 @@ def random_split(
         # get subset lengths
         subset_lengths = [math.floor(len(label_dataset.samples) * ratio) for ratio in split_ratio]
         for i in range(len(label_dataset.samples) - sum(subset_lengths)):
-            subset_idx = i % sum(subset_lengths)
+            subset_idx = i % len(subset_lengths)
             subset_lengths[subset_idx] += 1
         if 0 in subset_lengths:
             msg = """Zero subset length encountered during splitting. This means one of your subsets

--- a/tests/unit/data/utils/test_split.py
+++ b/tests/unit/data/utils/test_split.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dataset split utils."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from anomalib.data.datasets.image.folder import FolderDataset
+from anomalib.data.utils.split import random_split
+
+
+def _make_image(path: Path) -> None:
+    """Write a small dummy RGB image to ``path``."""
+    rng = np.random.default_rng(seed=len(str(path)))
+    image = rng.integers(0, 255, size=(32, 32, 3), dtype=np.uint8)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(image).save(path)
+
+
+def _make_folder_dataset(root: Path, num_normal: int, num_abnormal: int) -> FolderDataset:
+    """Create a ``FolderDataset`` backed by generated dummy images."""
+    for i in range(num_normal):
+        _make_image(root / "good" / f"{i:03d}.png")
+    for i in range(num_abnormal):
+        _make_image(root / "bad" / f"{i:03d}.png")
+    return FolderDataset(
+        name="dummy",
+        normal_dir=root / "good",
+        abnormal_dir=(root / "bad") if num_abnormal else None,
+    )
+
+
+class TestRandomSplit:
+    """Tests for the ``random_split`` function."""
+
+    @staticmethod
+    def test_ratio_preserves_total_length(tmp_path: Path) -> None:
+        """Split subsets must add up to the source dataset."""
+        dataset = _make_folder_dataset(tmp_path, num_normal=8, num_abnormal=4)
+        splits = random_split(dataset, [0.6, 0.4], seed=42)
+        assert len(splits) == 2
+        assert sum(len(split) for split in splits) == len(dataset)
+
+    @staticmethod
+    def test_label_aware_single_sample_label_group(tmp_path: Path) -> None:
+        """A label group with a single sample must not crash the split.
+
+        Regression test: when ``floor(len * ratio)`` was 0 for every ratio
+        (e.g. one sample with a 50/50 split), the remainder-distribution
+        loop computed ``i % sum(subset_lengths)`` = ``i % 0`` and raised
+        ``ZeroDivisionError``.
+        """
+        dataset = _make_folder_dataset(tmp_path, num_normal=1, num_abnormal=4)
+        splits = random_split(dataset, 0.5, label_aware=True, seed=42)
+        assert len(splits) == 2
+        assert sum(len(split) for split in splits) == len(dataset)
+
+    @staticmethod
+    def test_label_aware_keeps_labels_in_both_subsets(tmp_path: Path) -> None:
+        """Label-aware split keeps both labels represented when possible."""
+        dataset = _make_folder_dataset(tmp_path, num_normal=6, num_abnormal=6)
+        splits = random_split(dataset, 0.5, label_aware=True, seed=42)
+        for split in splits:
+            assert set(split.samples["label_index"]) == {0, 1}
+
+    @staticmethod
+    def test_invalid_ratio_sum_raises(tmp_path: Path) -> None:
+        """Ratios that do not sum to 1 must raise a ``ValueError``."""
+        dataset = _make_folder_dataset(tmp_path, num_normal=4, num_abnormal=0)
+        with pytest.raises(ValueError, match="must sum to 1"):
+            random_split(dataset, [0.5, 0.4])


### PR DESCRIPTION
## 📝 Description

Fixes #3679.

`random_split` distributes remainder samples with `subset_idx = i % sum(subset_lengths)`. When a label group is too small for the split ratios — e.g. a **single sample** with the default 50/50 label-aware val split — every `floor(len * ratio)` is 0, the sum is 0, and the modulo raises `ZeroDivisionError` from `datamodule.setup()` before training starts. Easy to hit with a small custom `Folder` dataset and no `normal_test_dir` (one normal image lands in the test set, and the default `ValSplitMode.FROM_TEST` crashes).

**Fix (one word):** distribute the remainder round-robin over the **subsets** — `i % len(subset_lengths)` — matching `torch.utils.data.random_split`. In the previously-working cases the chosen index is unchanged; in the crash case the sample goes to the first subset and the existing "Zero subset length" warning (which sits three lines below but could never fire) now fires as intended.

## ✨ Changes

- `src/anomalib/data/utils/split.py`: `sum(subset_lengths)` → `len(subset_lengths)` in the remainder-distribution loop.
- `tests/unit/data/utils/test_split.py` (new — there were no `random_split` tests): total-length preservation, the 1-sample-label-group regression test, label representation in label-aware splits, and the invalid-ratio guard. Tests build a real `FolderDataset` over `tmp_path`-generated images, no fixtures needed.

## ✅ Verification

- Regression test fails on the previous code with exactly `split.py:168: ZeroDivisionError` and passes with the fix.
- End-to-end: the `Folder.setup()` reproducer from #3679 now completes and logs the intended zero-subset-length warning.
- `tests/unit/data/utils`: 98 passed; remaining failures are environment-specific (missing `pytest_mock`, Windows permission-semantics tests) and unrelated to this change.

## 📋 Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes
