### PR TITLE
ci: Lock uv version for renovate bot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,6 +53,10 @@
   // `matchBaseBranches` in specific rule
   baseBranches: ["main"],
 
+  // Do not recreate PRs that were closed without merging.
+  // Note: security/vulnerability ("immortal") updates may still be recreated.
+  recreateWhen: "never",
+
   enabledManagers: [
     "github-actions",
     "pep621",
@@ -71,6 +75,13 @@
 
   // Apply a default blanket cooldown of 7 days to all dependencies
   minimumReleaseAge: "7 days",
+
+  // Pin the uv version Renovate uses to regenerate uv.lock so it matches the
+  // version pinned in the GitHub Actions workflows (and the astral/uv image).
+  // This prevents uv.lock format/resolver drift between Renovate and CI.
+  constraints: {
+    uv: "0.9.18",
+  },
 
   packageRules: [
     // Enable pinning for container images

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -77,7 +77,7 @@
   minimumReleaseAge: "7 days",
 
   // Pin the uv version Renovate uses to regenerate uv.lock so it matches the
-  // version pinned in the GitHub Actions workflows (and the astral/uv image).
+  // version pinned in the GitHub Actions workflows.
   // This prevents uv.lock format/resolver drift between Renovate and CI.
   constraints: {
     uv: "0.9.18",

--- a/.github/workflows/tauri-build.yaml
+++ b/.github/workflows/tauri-build.yaml
@@ -221,7 +221,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0 # zizmor: ignore[cache-poisoning]
         with:
-          version: "latest"
+          version: "0.9.18"
           enable-cache: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Install Rust
@@ -263,7 +263,7 @@ jobs:
         env:
           MATRIX_ACCELERATOR: ${{ matrix.accelerator }}
         run: |
-          uv sync --no-dev --extra $env:MATRIX_ACCELERATOR
+          uv sync --frozen --no-dev --extra $env:MATRIX_ACCELERATOR
           uv pip install pyinstaller==6.19.0
           .\.venv\Scripts\Activate.ps1
           Push-Location ..\binary\sidecar


### PR DESCRIPTION
## 📝 Description

Locking uv tool version for renovate bot, it is aligned to what is used in anomalib-studio workflow. Same is doen for tauri-build workflow.

- 🛠️ Fixes #3666 

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [x] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [ ] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
