### PR TITLE
test(engine): cover full checkpoint loading

### DIFF
--- a/tests/unit/engine/test_engine.py
+++ b/tests/unit/engine/test_engine.py
@@ -4,11 +4,13 @@
 """Test Engine Module."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import yaml
 from lightning import seed_everything
 
+from anomalib import LearningType
 from anomalib.data import MVTecAD
 from anomalib.engine import Engine
 from anomalib.models import Padim
@@ -122,6 +124,34 @@ class TestEngine:
         engine, model, datamodule = Engine.from_config(config_path=fxt_full_config_path, **override_kwargs)
         assert datamodule.train_batch_size == 1
         assert datamodule.num_workers == 1
+
+    @staticmethod
+    def test_predict_loads_full_checkpoint_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Ensure prediction can restore checkpoints containing custom objects."""
+        engine = Engine(default_root_dir=tmp_path)
+        trainer = MagicMock()
+        monkeypatch.setattr(engine, "_trainer", trainer)
+
+        model = MagicMock()
+        model.name = "custom-model"
+        model.trainer_arguments = {}
+        model.learning_type = LearningType.ONE_CLASS
+
+        checkpoint_path = tmp_path / "model.ckpt"
+        expected_predictions = [MagicMock()]
+        trainer.predict.return_value = expected_predictions
+
+        predictions = engine.predict(model=model, ckpt_path=checkpoint_path)
+
+        trainer.predict.assert_called_once_with(
+            model,
+            None,
+            None,
+            None,
+            checkpoint_path.resolve(),
+            weights_only=False,
+        )
+        assert predictions is expected_predictions
 
     @staticmethod
     def test_barebones_mode_metrics_and_checkpointing(tmp_path: Path, dataset_path: Path) -> None:


### PR DESCRIPTION
## 📝 Description

Adds regression coverage for checkpoint restoration during `Engine.predict()`.

PyTorch defaults to weights-only checkpoint loading, which cannot restore checkpoints whose saved state includes custom objects such as a `PreProcessor`. The engine intentionally passes `weights_only=False`; this test makes that behavior explicit and protects it from regression.

Related to #3612.

## ✨ Changes

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [x] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] 📚 Documentation is not required for this test-only change.
- [x] 🧪 I have written tests that support the expected checkpoint-loading behavior.
- [x] 🏷️ My PR title follows conventional commit format.

## 🧪 Validation

- `uv run --extra cpu --extra dev pytest tests/unit/engine/test_engine.py -q`
- `uv run prek run --files tests/unit/engine/test_engine.py`
