### PR TITLE
fix(metrics): use tensor boolean reduction in F1AdaptiveThreshold sample validation

### DIFF
--- a/src/anomalib/metrics/threshold/f1_adaptive_threshold.py
+++ b/src/anomalib/metrics/threshold/f1_adaptive_threshold.py
@@ -105,7 +105,7 @@ class _F1AdaptiveThreshold(BinaryPrecisionRecallCurve, Threshold):
             bool: True if anomalous samples (target=1) exist, False otherwise.
         """
         if self.thresholds is None:
-            return any(1 in batch for batch in self.target)
+            return any((batch == 1).any().item() for batch in self.target)
         # confmat[i] = [[TN, FP], [FN, TP]]; positives = FN + TP  #  noqa: ERA001
         return (self.confmat[0, 1, 0] + self.confmat[0, 1, 1]).item() > 0
 
@@ -116,7 +116,7 @@ class _F1AdaptiveThreshold(BinaryPrecisionRecallCurve, Threshold):
             bool: True if normal samples (target=0) exist, False otherwise.
         """
         if self.thresholds is None:
-            return any(0 in batch for batch in self.target)
+            return any((batch == 0).any().item() for batch in self.target)
         # confmat[i] = [[TN, FP], [FN, TP]]; negatives = TN + FP  # noqa: ERA001
         return (self.confmat[0, 0, 0] + self.confmat[0, 0, 1]).item() > 0
 

--- a/tests/unit/metrics/threshold/test_threshold.py
+++ b/tests/unit/metrics/threshold/test_threshold.py
@@ -49,3 +49,34 @@ class TestBaseThreshold:
 
         with pytest.raises(NotImplementedError, match=r"Subclass of Threshold must implement the update method"):
             base_threshold.update()
+
+
+class TestF1AdaptiveThreshold:
+    """Test cases for F1AdaptiveThreshold class."""
+
+    @staticmethod
+    def test_normal_samples_only() -> None:
+        """Test threshold computation when only normal samples are present."""
+        import torch
+        from anomalib.metrics.threshold.f1_adaptive_threshold import _F1AdaptiveThreshold
+
+        metric = _F1AdaptiveThreshold()
+        preds = torch.tensor([0.1, 0.2, 0.3])
+        targets = torch.tensor([0, 0, 0])
+        metric.update(preds, targets)
+        threshold = metric.compute()
+        assert threshold == torch.tensor(0.3)
+
+    @staticmethod
+    def test_anomalous_samples_only() -> None:
+        """Test threshold computation when only anomalous samples are present."""
+        import torch
+        from anomalib.metrics.threshold.f1_adaptive_threshold import _F1AdaptiveThreshold
+
+        metric = _F1AdaptiveThreshold()
+        preds = torch.tensor([0.7, 0.8, 0.9])
+        targets = torch.tensor([1, 1, 1])
+        metric.update(preds, targets)
+        threshold = metric.compute()
+        assert threshold == torch.tensor(0.7)
+


### PR DESCRIPTION
### Description

Fixes sample presence checks in `_F1AdaptiveThreshold`:
- In `_has_anomalous_samples` and `_has_normal_samples`, replace Python `1 in batch` / `0 in batch` membership tests with vectorized PyTorch boolean reductions `(batch == 1).any().item()` and `(batch == 0).any().item()`.
- Ensures reliable detection of missing anomalous/normal classes and correct fallback to `_get_max_pred()` or `_get_min_pred()`.
- Adds unit tests in `tests/unit/metrics/threshold/test_threshold.py` covering normal-only and anomalous-only validation batches.
