### PR TITLE
fix(data): block tar/zip path traversal on all supported Python versions

### DIFF
--- a/src/anomalib/data/utils/download.py
+++ b/src/anomalib/data/utils/download.py
@@ -192,16 +192,26 @@ def safe_extract(tar_file: TarFile, root: Path, members: list[TarInfo]) -> None:
         members: List of safe members to extract
     """
     for member in members:
+        member_path = root / member.name
+        # Reject absolute paths and members that would resolve outside of
+        # ``root`` (path traversal via ``..`` segments, symlinks, etc.). This
+        # check is applied on all supported Python versions, since the
+        # ``filter="data"`` protection below is only available on
+        # Python>=3.11.4.
+        if Path(member.name).is_absolute() or not is_within_directory(root, member_path):
+            logger.warning("Skipping potentially unsafe archive member: %s", member.name)
+            continue
+
         # check if the file already exists
-        if not (root / member.name).exists():
+        if not member_path.exists():
             if sys.version_info[:3] >= (3, 11, 4):
                 # filter argument only works with python>=3.11.4
                 tar_file.extract(member, root, filter="data")
             else:
                 tar_file.extract(member, root)
         if member.isdir():
-            extracted_path = (root / member.name).resolve()
-            if extracted_path.is_relative_to(root.resolve()) and extracted_path.is_dir():
+            extracted_path = member_path.resolve()
+            if extracted_path.is_dir():
                 with contextlib.suppress(OSError):
                     extracted_path.chmod(extracted_path.stat().st_mode | 0o700)
 
@@ -274,8 +284,14 @@ def extract(file_name: Path, root: Path) -> None:
     if file_name.suffix == ".zip":
         with ZipFile(file_name, "r") as zip_file:
             for file_info in zip_file.infolist():
-                if not is_file_potentially_dangerous(file_info.filename):
-                    zip_file.extract(file_info, root)
+                member_path = root / file_info.filename
+                if is_file_potentially_dangerous(file_info.filename):
+                    logger.warning("Skipping potentially unsafe archive member: %s", file_info.filename)
+                    continue
+                if Path(file_info.filename).is_absolute() or not is_within_directory(root, member_path):
+                    logger.warning("Skipping potentially unsafe archive member: %s", file_info.filename)
+                    continue
+                zip_file.extract(file_info, root)
 
     # Safely extract tar files.
     elif file_name.suffix in {".tar", ".gz", ".xz", ".tgz"}:

--- a/src/anomalib/data/utils/download.py
+++ b/src/anomalib/data/utils/download.py
@@ -194,11 +194,17 @@ def safe_extract(tar_file: TarFile, root: Path, members: list[TarInfo]) -> None:
     for member in members:
         member_path = root / member.name
         # Reject absolute paths and members that would resolve outside of
-        # ``root`` (path traversal via ``..`` segments, symlinks, etc.). This
-        # check is applied on all supported Python versions, since the
-        # ``filter="data"`` protection below is only available on
-        # Python>=3.11.4.
-        if Path(member.name).is_absolute() or not is_within_directory(root, member_path):
+        # ``root`` (path traversal via ``..`` segments, symlinks, etc.). Also
+        # reject non-regular members (symlinks, hardlinks, devices, fifos,
+        # etc.), which the ``filter="data"`` protection below already blocks
+        # on Python>=3.11.4. These checks are applied on all supported
+        # Python versions, since ``filter="data"`` is unavailable on older
+        # ones.
+        if (
+            Path(member.name).is_absolute()
+            or not is_within_directory(root, member_path)
+            or not (member.isfile() or member.isdir())
+        ):
             logger.warning("Skipping potentially unsafe archive member: %s", member.name)
             continue
 

--- a/tests/unit/data/utils/test_download.py
+++ b/tests/unit/data/utils/test_download.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for download utils."""
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from anomalib.data.utils.download import extract, is_within_directory
+
+
+class TestIsWithinDirectory:
+    """Tests for ``is_within_directory`` function."""
+
+    @staticmethod
+    def test_path_inside_directory() -> None:
+        """Test that a path inside the directory is correctly identified."""
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            target = root / "safe" / "file.txt"
+            assert is_within_directory(root, target) is True
+
+    @staticmethod
+    def test_path_traversal_outside_directory() -> None:
+        """Test that a path escaping the directory via ``..`` is rejected."""
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir) / "root"
+            target = root / ".." / ".." / "etc" / "passwd"
+            assert is_within_directory(root, target) is False
+
+    @staticmethod
+    def test_absolute_path_outside_directory() -> None:
+        """Test that an absolute path outside the directory is rejected."""
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir) / "root"
+            target = Path("/etc/passwd")
+            assert is_within_directory(root, target) is False
+
+
+class TestExtract:
+    """Tests for ``extract`` function against malicious archives."""
+
+    @staticmethod
+    def test_tar_path_traversal_is_blocked() -> None:
+        """Test that tar members with ``../`` traversal are not extracted outside root."""
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            archive_path = base / "malicious.tar.gz"
+            extract_root = base / "extracted"
+            extract_root.mkdir()
+            outside_marker = base / "evil.txt"
+
+            with tarfile.open(archive_path, "w:gz") as tar:
+                # Safe member should still be extracted normally.
+                safe_info = tarfile.TarInfo(name="safe.txt")
+                safe_data = b"safe content"
+                safe_info.size = len(safe_data)
+                tar.addfile(safe_info, fileobj=io.BytesIO(safe_data))
+
+                # Traversal member should be rejected.
+                evil_info = tarfile.TarInfo(name="../evil.txt")
+                evil_data = b"evil content"
+                evil_info.size = len(evil_data)
+                tar.addfile(evil_info, fileobj=io.BytesIO(evil_data))
+
+            extract(archive_path, extract_root)
+
+            assert (extract_root / "safe.txt").exists()
+            assert not outside_marker.exists()
+
+    @staticmethod
+    def test_tar_absolute_path_is_blocked() -> None:
+        """Test that tar members with absolute paths are not extracted outside root."""
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            archive_path = base / "malicious_abs.tar.gz"
+            extract_root = base / "extracted"
+            extract_root.mkdir()
+            outside_marker = base / "abs_evil.txt"
+
+            with tarfile.open(archive_path, "w:gz") as tar:
+                evil_info = tarfile.TarInfo(name=str(outside_marker))
+                evil_data = b"evil content"
+                evil_info.size = len(evil_data)
+                tar.addfile(evil_info, fileobj=io.BytesIO(evil_data))
+
+            extract(archive_path, extract_root)
+
+            assert not outside_marker.exists()
+
+    @staticmethod
+    def test_zip_path_traversal_is_blocked() -> None:
+        """Test that zip members with ``../`` traversal are not extracted outside root."""
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            archive_path = base / "malicious.zip"
+            extract_root = base / "extracted"
+            extract_root.mkdir()
+            outside_marker = base / "evil.txt"
+
+            with zipfile.ZipFile(archive_path, "w") as zip_file:
+                zip_file.writestr("safe.txt", "safe content")
+                zip_file.writestr("../evil.txt", "evil content")
+
+            extract(archive_path, extract_root)
+
+            assert (extract_root / "safe.txt").exists()
+            assert not outside_marker.exists()

--- a/tests/unit/data/utils/test_download.py
+++ b/tests/unit/data/utils/test_download.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for download utils."""
@@ -90,6 +90,31 @@ class TestExtract:
             extract(archive_path, extract_root)
 
             assert not outside_marker.exists()
+
+    @staticmethod
+    def test_tar_symlink_member_is_blocked() -> None:
+        """Test that non-regular tar members (e.g. symlinks) are not extracted."""
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            archive_path = base / "malicious_symlink.tar.gz"
+            extract_root = base / "extracted"
+            extract_root.mkdir()
+
+            with tarfile.open(archive_path, "w:gz") as tar:
+                safe_info = tarfile.TarInfo(name="safe.txt")
+                safe_data = b"safe content"
+                safe_info.size = len(safe_data)
+                tar.addfile(safe_info, fileobj=io.BytesIO(safe_data))
+
+                link_info = tarfile.TarInfo(name="evil_link")
+                link_info.type = tarfile.SYMTYPE
+                link_info.linkname = "/etc/passwd"
+                tar.addfile(link_info)
+
+            extract(archive_path, extract_root)
+
+            assert (extract_root / "safe.txt").exists()
+            assert not (extract_root / "evil_link").exists()
 
     @staticmethod
     def test_zip_path_traversal_is_blocked() -> None:


### PR DESCRIPTION
## 📝 Description

- Currently `safe_extract` relies on `filter=data` option for checking path traversal. Since anomalib supports version 3.10 and above, this option has no effect between 3.10 and 3.11.4.


## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [x] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
