### PR TITLE
fix(data): honour tile width in random tiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- 🐞 **data**: Random tiling now honours the configured tile width instead of always producing square tiles
+
 ## [v2.6.0] - 2026-07-24
 
 ### Added

--- a/src/anomalib/data/utils/tiler.py
+++ b/src/anomalib/data/utils/tiler.py
@@ -281,7 +281,9 @@ class Tiler:
         Returns:
             torch.Tensor: Stack of random tiles
         """
-        return torch.vstack([T.RandomCrop(self.tile_size_h)(image) for i in range(self.random_tile_count)])
+        return torch.vstack(
+            [T.RandomCrop((self.tile_size_h, self.tile_size_w))(image) for _ in range(self.random_tile_count)],
+        )
 
     def __unfold(self, tensor: torch.Tensor) -> torch.Tensor:
         """Unfold tensor into tiles.

--- a/tests/unit/data/utils/test_tiler.py
+++ b/tests/unit/data/utils/test_tiler.py
@@ -63,6 +63,14 @@ def test_tiler_handles_single_image_without_batch_dimension(
     assert patches.shape == shape
 
 
+def test_random_tiling_respects_non_square_tile_size() -> None:
+    """Random tiling should use both tile height and width, not a square crop."""
+    tiler = Tiler(tile_size=(128, 256), stride=(128, 256))
+    image = torch.rand(1, 3, 512, 512)
+    patches = tiler.tile(image, use_random_tiling=True)
+    assert patches.shape == torch.Size([4, 3, 128, 256])
+
+
 def test_stride_size_cannot_be_larger_than_tile_size() -> None:
     """Larger stride size than tile size is not desired, and causes issues."""
     kernel_size = (128, 128)


### PR DESCRIPTION
## 📝 Description

- T.RandomCrop with a single int makes a square crop, so a non-square tile_size like (128, 256) produced (128, 128) random tiles. Grid tiling already used both dims, so the two modes disagreed.
- Fixes #3768

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
