### PR TITLE
fix(CI): gate issue triage on maintainer-applied triage label

### DIFF
--- a/.github/scripts/apply-issue-triage.sh
+++ b/.github/scripts/apply-issue-triage.sh
@@ -9,19 +9,47 @@
 # reach it except as inert data inside a JSON field, which is validated
 # against strict allowlists/limits below before any `gh` write command runs.
 #
-# Required env vars: GH_TOKEN, GITHUB_REPOSITORY, ISSUE_NUMBER, SUGGESTION
+# Required env vars: GH_TOKEN, GITHUB_REPOSITORY, ISSUE_NUMBER, SUGGESTION,
+# LABELED_AT
 
 set -euo pipefail
 
 : "${GITHUB_REPOSITORY:?}"
 : "${ISSUE_NUMBER:?}"
+: "${LABELED_AT:?}"
 SUGGESTION="${SUGGESTION:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/triage-lib.sh
+source "${SCRIPT_DIR}/triage-lib.sh"
 
 MAX_LABELS=3
 MAX_COMMENT_CHARS=2000
 
+# Drop the request label once the pipeline is done with the issue, so a
+# completed (or abandoned) run can't be replayed and re-triage always
+# requires a maintainer to deliberately re-apply the label.
+remove_triage_label() {
+  gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+    --remove-label "$TRIAGE_LABEL" >/dev/null 2>&1 ||
+    echo "::warning::Could not remove the '${TRIAGE_LABEL}' label."
+}
+
+# --- TOCTOU re-check ------------------------------------------------------
+# The `gate` job already verified the issue was unedited when triage was
+# requested, but `analyze` can run for up to 20 minutes after that. An
+# issue edited during that window would mean the maintainer approved one
+# body while the agent read another, so re-verify here — this job holds
+# `issues: write` and is the last point before anything is mutated.
+if triage_is_stale "$LABELED_AT"; then
+  echo "Issue changed after triage was requested; skipping all writes."
+  remove_triage_label
+  exit 0
+fi
+
 if [[ -z "$SUGGESTION" ]]; then
   echo "No suggestion produced by analyze job; nothing to apply."
+  remove_triage_label
   exit 0
 fi
 
@@ -30,6 +58,7 @@ if ! echo "$SUGGESTION" | jq empty >/dev/null 2>&1; then
   # influenced and can contain newlines / `::...::` sequences, enabling
   # workflow-command injection (fake annotations, stop-commands, etc.).
   echo "::warning::Triage suggestion is not valid JSON, discarding output from analyze job."
+  remove_triage_label
   exit 0
 fi
 
@@ -46,6 +75,10 @@ done < <(echo "$SUGGESTION" | jq -r 'try (.labels[]) catch empty' | head -n "$MA
 
 APPLY_LABELS=()
 for label in "${SUGGESTED_LABELS[@]+"${SUGGESTED_LABELS[@]}"}"; do
+  # The request label is control plane, not a classification: never let a
+  # suggestion re-apply it (the run would be replayable) even though it is
+  # a real repository label.
+  [[ "$label" == "$TRIAGE_LABEL" ]] && continue
   for valid in "${VALID_LABELS[@]+"${VALID_LABELS[@]}"}"; do
     if [[ "$label" == "$valid" ]]; then
       APPLY_LABELS+=("$label")
@@ -107,5 +140,7 @@ if [[ "$ACTIONABLE" == "true" && -n "$COMMENT" && "$COMMENT" != "null" ]]; then
 else
   echo "No actionable comment to post."
 fi
+
+remove_triage_label
 
 # NOTE: this script intentionally never closes, locks, or assigns the issue.

--- a/.github/scripts/check-triage-gate.sh
+++ b/.github/scripts/check-triage-gate.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Decides whether an issue is allowed to enter the OpenCode triage
+# pipeline. Runs read-only, on a hosted runner, BEFORE any work is
+# scheduled on the self-hosted GPU runner.
+#
+# Two conditions must hold:
+#   1. The `triage` label was applied by someone with write access.
+#   2. The issue content has not been edited since that label was applied
+#      (TOCTOU: otherwise a maintainer's approval could be swapped out for
+#      arbitrary content before the agent ever reads the issue).
+#
+# Writes `approved` and `labeled_at` to $GITHUB_OUTPUT. This script never
+# mutates anything on GitHub; cleanup on rejection is the `reject` job's
+# responsibility.
+#
+# Required env vars: GH_TOKEN, GITHUB_REPOSITORY, ISSUE_NUMBER,
+# SENDER_LOGIN, GITHUB_OUTPUT
+
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?}"
+: "${ISSUE_NUMBER:?}"
+: "${SENDER_LOGIN:?}"
+: "${GITHUB_OUTPUT:?}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/triage-lib.sh
+source "${SCRIPT_DIR}/triage-lib.sh"
+
+deny() {
+  echo "Triage NOT approved: $1"
+  {
+    echo "approved=false"
+    echo "reason=$2"
+  } >> "$GITHUB_OUTPUT"
+  exit 0
+}
+
+# --- 1. Was the label applied by a maintainer? ----------------------------
+#
+# GitHub already requires triage-or-higher repository access to apply a
+# label, so reaching this script at all implies the sender is trusted to
+# some degree. The explicit permission check below narrows that to
+# write/maintain/admin as defense in depth.
+#
+# The collaborator-permission endpoint is not guaranteed to be reachable
+# with this workflow's minimal token scopes. If the call fails we log and
+# fall back to GitHub's built-in "only triage+ users can label" guarantee
+# rather than hard-failing every run — but we never *widen* access here.
+PERMISSION=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${SENDER_LOGIN}/permission" \
+  --jq '.permission' 2>/dev/null || echo "")
+
+if [[ -z "$PERMISSION" ]]; then
+  echo "::warning::Could not read repository permission for the labeling user; \
+relying on GitHub's requirement that only users with triage access can apply labels."
+else
+  case "$PERMISSION" in
+    admin | maintain | write)
+      echo "Label applied by a user with '${PERMISSION}' access."
+      ;;
+    *)
+      deny "label was applied by a user with '${PERMISSION}' access, which is below write." "permission"
+      ;;
+  esac
+fi
+
+# --- 2. Has the issue been edited since it was labeled? -------------------
+LABELED_AT="$(triage_labeled_at)"
+
+if triage_is_stale "$LABELED_AT"; then
+  deny "issue content changed after the '${TRIAGE_LABEL}' label was applied." "stale"
+fi
+
+echo "Triage approved for issue #${ISSUE_NUMBER}."
+{
+  echo "approved=true"
+  echo "labeled_at=${LABELED_AT}"
+} >> "$GITHUB_OUTPUT"

--- a/.github/scripts/triage-lib.sh
+++ b/.github/scripts/triage-lib.sh
@@ -1,0 +1,96 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# shellcheck shell=bash
+#
+# Shared helpers for the OpenCode issue-triage pipeline.
+#
+# This file is meant to be sourced, not executed. It contains the TOCTOU
+# guard used by both the `gate` job (before any GPU/LLM work starts) and
+# the `apply` job (after it finishes, since the issue can be edited during
+# the up-to-20-minute analyze window).
+#
+# Required env vars for all functions: GH_TOKEN, GITHUB_REPOSITORY,
+# ISSUE_NUMBER.
+
+# Label a maintainer applies to request triage. Overridable for testing.
+TRIAGE_LABEL="${TRIAGE_LABEL:-triage}"
+export TRIAGE_LABEL
+
+# Timestamp (ISO-8601 UTC) of the most recent time the triage label was
+# applied to the issue. Empty if the label was never applied.
+#
+# GitHub's `issues.labeled` webhook payload does not carry the label
+# application time, so it has to be recovered from the issue timeline.
+triage_labeled_at() {
+  gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/timeline" \
+    --paginate \
+    -H "Accept: application/vnd.github+json" \
+    --jq '.[] | select(.event == "labeled") | select(.label.name == env.TRIAGE_LABEL) | .created_at' |
+    sort | tail -n 1
+}
+
+# Timestamp (ISO-8601 UTC) of the last edit to the issue's *content*.
+#
+# Deliberately NOT `issue.updated_at`: that field is bumped by comments,
+# label changes, assignment, milestones, etc., so comparing against it
+# would abort valid triage runs constantly. The content-edit signals are:
+#   - `lastEditedAt` (GraphQL)  -> body edits
+#   - `renamed` timeline events -> title edits
+# The later of the two is returned. Empty if the issue was never edited.
+triage_last_edited_at() {
+  local owner="${GITHUB_REPOSITORY%%/*}"
+  local repo="${GITHUB_REPOSITORY##*/}"
+  local body_edit title_edit
+
+  # shellcheck disable=SC2016 # $owner/$repo/$number are GraphQL variables, not shell ones.
+  body_edit=$(gh api graphql \
+    -f query='query($owner:String!,$repo:String!,$number:Int!){
+      repository(owner:$owner,name:$repo){issue(number:$number){lastEditedAt}}
+    }' \
+    -f owner="$owner" -f repo="$repo" -F number="$ISSUE_NUMBER" \
+    --jq '.data.repository.issue.lastEditedAt // empty')
+
+  title_edit=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/timeline" \
+    --paginate \
+    -H "Accept: application/vnd.github+json" \
+    --jq '.[] | select(.event == "renamed") | .created_at' |
+    sort | tail -n 1)
+
+  printf '%s\n%s\n' "$body_edit" "$title_edit" | grep -v '^$' | sort | tail -n 1
+}
+
+# Returns 0 (stale) if the issue content was edited after the triage label
+# was applied — i.e. the maintainer vouched for content that is no longer
+# what the pipeline would act on. Returns 1 (fresh) otherwise.
+#
+# Fails closed: a missing label timestamp is treated as stale.
+#
+# GitHub returns both timestamps as `YYYY-MM-DDTHH:MM:SSZ`, a fixed-width
+# UTC format, so lexicographic comparison is equivalent to chronological.
+#
+# Usage: triage_is_stale "$LABELED_AT"
+triage_is_stale() {
+  local labeled_at="${1:-}"
+  local last_edit
+
+  if [[ -z "$labeled_at" ]]; then
+    echo "No '${TRIAGE_LABEL}' label application found on issue #${ISSUE_NUMBER}; failing closed."
+    return 0
+  fi
+
+  last_edit=$(triage_last_edited_at)
+
+  if [[ -z "$last_edit" ]]; then
+    echo "Issue #${ISSUE_NUMBER} has never been edited; content is unchanged since labeling."
+    return 1
+  fi
+
+  if [[ "$last_edit" > "$labeled_at" ]]; then
+    echo "Issue #${ISSUE_NUMBER} was edited at ${last_edit}, after the '${TRIAGE_LABEL}' label was applied at ${labeled_at}."
+    return 0
+  fi
+
+  echo "Issue #${ISSUE_NUMBER} last edited at ${last_edit}, before the '${TRIAGE_LABEL}' label was applied at ${labeled_at}."
+  return 1
+}

--- a/.github/workflows/opencode-issue-triage.yml
+++ b/.github/workflows/opencode-issue-triage.yml
@@ -5,27 +5,72 @@ name: "Issue Triage (OpenCode)"
 
 on:
   issues:
-    types: [opened]
+    types: [labeled]
 
 permissions: {} # No permissions by default on workflow level
 
 concurrency:
   group: "opencode-issue-triage-${{ github.event.issue.number }}"
 
+env:
+  TRIAGE_LABEL: triage
+
 jobs:
-  # Stage 1: analyze the (untrusted) issue body and produce a suggestion.
-  # Runs for EVERY issue author, including first-timers — this job never
-  # holds `issues: write`, so a prompt-injection payload in the issue body
-  # cannot mutate anything on GitHub. It can only steer this job's own
-  # (harmless, read-only) output, which the `apply` job independently
-  # validates before acting on it.
+  # Stage 0: decide whether this issue may enter the pipeline at all.
+  #
+  # Triage is opt-in: a maintainer requests it by applying the `triage`
+  # label. That keeps arbitrary GitHub users from scheduling LLM runs on
+  # the self-hosted GPU runner simply by opening an issue, and gives a
+  # human checkpoint on the untrusted content the agent will read.
+  #
+  # Runs on a hosted runner and read-only, so the decision itself costs no
+  # GPU time and holds no write access.
+  gate:
+    if: github.event.label.name == 'triage'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read # Required to checkout the gate scripts
+      issues: read # Required to read the issue timeline; no write access here
+    outputs:
+      approved: ${{ steps.gate.outputs.approved }}
+      labeled_at: ${{ steps.gate.outputs.labeled_at }}
+      reason: ${{ steps.gate.outputs.reason }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: true
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Check triage request is authorized and current
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          # Passed as env, never interpolated into the script body.
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+        run: bash .github/scripts/check-triage-gate.sh
+
+  # Stage 1: analyze the (maintainer-approved but still untrusted) issue
+  # body and produce a suggestion. A maintainer applying the `triage` label
+  # is a request to look at the issue, not a review of its contents, so the
+  # body is still treated as hostile: this job never holds `issues: write`,
+  # so a prompt-injection payload in it cannot mutate anything on GitHub.
+  # It can only steer this job's own (harmless, read-only) output, which
+  # the `apply` job independently validates before acting on it.
   analyze:
+    needs: gate
+    if: needs.gate.outputs.approved == 'true'
     runs-on: self-hosted
     timeout-minutes: 20
-    # Serialize across ALL issues (not just per-issue) so a burst of issues
-    # opened by untrusted authors can't run many concurrent LLM invocations
-    # on the self-hosted GPU runner at once. Jobs queue instead of piling up
-    # in parallel; `cancel-in-progress: false` so none get silently dropped.
+    # Serialize across ALL issues (not just per-issue) so a burst of triage
+    # requests can't run many concurrent LLM invocations on the self-hosted
+    # GPU runner at once. Jobs queue instead of piling up in parallel;
+    # `cancel-in-progress: false` so none get silently dropped.
     # This bounds resource exhaustion; it does not grant any write access —
     # that boundary is enforced by `permissions` below and by the `apply`
     # job's independent validation.
@@ -84,13 +129,14 @@ jobs:
             echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
 
-  # Stage 2: apply the suggestion. This is the only job with `issues:
-  # write`. It runs plain, deterministic shell code (not an LLM) that
+  # Stage 2: apply the suggestion. This is the only job that acts on model
+  # output while holding `issues: write`. It runs plain, deterministic
+  # shell code (not an LLM) that re-verifies the issue is unchanged and
   # validates every field of the Stage 1 suggestion against explicit
   # allowlists/limits before calling any mutating `gh` command. See
   # .github/scripts/apply-issue-triage.sh.
   apply:
-    needs: analyze
+    needs: [gate, analyze]
     runs-on: self-hosted
     timeout-minutes: 5
     permissions:
@@ -111,4 +157,29 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           SUGGESTION: ${{ needs.analyze.outputs.suggestion }}
+          LABELED_AT: ${{ needs.gate.outputs.labeled_at }}
         run: bash .github/scripts/apply-issue-triage.sh
+
+  # Cleanup path for rejected requests. Kept separate from `gate` so the
+  # decision stays read-only, and separate from `apply` so this job never
+  # touches model output: it only removes the request label and posts a
+  # fixed, hard-coded string.
+  reject:
+    needs: gate
+    if: needs.gate.outputs.approved == 'false' && needs.gate.outputs.reason == 'stale'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write # Required to remove the label and explain why
+    steps:
+      - name: Withdraw triage request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --remove-label "$TRIAGE_LABEL"
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --body "This issue was edited after the \`$TRIAGE_LABEL\` label was applied, so automated triage was skipped. A maintainer can re-apply the label to run it against the current content."


### PR DESCRIPTION
## Description

Follow-up to #3770, addressing https://github.com/open-edge-platform/anomalib/pull/3770#discussion_r3924239917 (thanks @AlexanderBarabanov).

That PR replaced the `author_association` check with a two-stage `analyze` (read-only LLM) → `apply` (deterministic, allowlist-validated) split. That closes the *mutation* vector, but the workflow still triggered on `issues: opened`, so any GitHub user could schedule an up-to-20-minute LLM run on the self-hosted GPU runner just by filing an issue.

Triage is now **opt-in**: a maintainer requests it by applying the `triage` label.

### Changes

- **`issues: [labeled]` trigger**, gated on `github.event.label.name == 'triage'`. No longer runs automatically on newly opened issues.
- **New `gate` job** — hosted runner, `issues: read`, no GPU. Verifies the labeler has write/maintain/admin access and that the issue has not been edited since the label was applied. Emits `approved` / `labeled_at`; `analyze` only runs on `approved == 'true'`.
- **TOCTOU re-check in `apply`** — the gate check alone is insufficient, since `analyze` can run for 20 minutes after labeling. `apply-issue-triage.sh` re-verifies before it writes anything, so an edit landing mid-run cannot swap out the content the maintainer approved.
- **New `reject` job** — removes the label and posts a fixed, hard-coded string when a request is rejected as stale. Kept separate from `gate` so the decision stays read-only, and separate from `apply` so it never touches model output.
- **Replay prevention** — the `triage` label is removed once the pipeline finishes with an issue, and a suggestion can never re-apply it.
- New `triage-lib.sh` holds the shared timestamp helpers used by both the gate and apply paths.

### Notes for reviewers

- **`lastEditedAt`, not `updated_at`.** The review comment suggested comparing against the issue's last-modified timestamp, but `updated_at` is bumped by comments, label changes, assignment and milestones, so it would abort valid runs constantly. This uses GraphQL `lastEditedAt` (body edits) combined with `renamed` timeline events (title edits), taking the later of the two. Both are fixed-width UTC, so lexicographic comparison is chronological.
- **Label timestamp source.** The `labeled` webhook payload does not carry the label application time, so it is recovered from the issue timeline.
- **Fail-closed on a missing label timestamp**, treated as stale.
- **Permission check degrades gracefully.** If the collaborator-permission endpoint is unreachable with this workflow's minimal token scopes, the run logs a warning and falls back to GitHub's built-in requirement that only users with triage-or-higher access can apply labels. It never widens access. Happy to make this a hard failure instead if you'd prefer.
- The job-level `if` uses the literal string `'triage'` because the workflow-level `env` is not available in job-level `if` expressions.

### Prerequisite :warning:

**The `triage` label must be created in this repository before this merges.** There is no labels-as-code file in `.github/`, so this is a one-time manual step. Until the label exists the workflow is simply a no-op.

## Checks

- `actionlint` clean
- `shellcheck -x` clean on all three scripts
- `pre-commit` (incl. `zizmor`, `prettier`, `check-yaml`) passing
- Timestamp comparison logic exercised locally against stubbed API responses: edit-before-label, edit-after-label, never-edited, missing-label-timestamp, same-second, and cross-year cases all behave as intended