### PR TITLE
fix(data): restrict Tabular.from_file to safe pandas readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- 🔒 **security**: Restrict `Tabular.from_file()` to the `csv`, `json` and `parquet` formats by @ashwinvaidya17 in
+
 ## [v2.6.1] - 2026-09-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- 🔒 **security**: Restrict `Tabular.from_file()` to the `csv`, `json` and `parquet` formats by @ashwinvaidya17 in
+- 🔒 **security**: Restrict `Tabular.from_file()` to the `csv`, `json` and `parquet` formats by @ashwinvaidya17 in https://github.com/open-edge-platform/anomalib/pull/3782
 
 ## [v2.6.1] - 2026-09-04
 

--- a/src/anomalib/data/datamodules/image/tabular.py
+++ b/src/anomalib/data/datamodules/image/tabular.py
@@ -188,7 +188,7 @@ class Tabular(AnomalibDataModule):
                 especially when logging/saving.
             file_path (str | Path): Path to tabular file containing the datset
                 information.
-            file_format (str): File format of the tabular file. Must be one of
+            file_format (str | None): File format of the tabular file. Must be one of
                 ``csv``, ``json`` or ``parquet`` (case-insensitive).
                 Defaults to ``None`` (inferred from the file suffix).
             pd_kwargs (dict | None): Keyword argument dictionary for the pd.read_* method.

--- a/src/anomalib/data/datamodules/image/tabular.py
+++ b/src/anomalib/data/datamodules/image/tabular.py
@@ -31,6 +31,15 @@ from anomalib.data.datamodules.base.image import AnomalibDataModule
 from anomalib.data.datasets.image.tabular import TabularDataset
 from anomalib.data.utils import Split, TestSplitMode, ValSplitMode
 
+# Allowlist of file formats supported by ``Tabular.from_file``.
+#
+# This is intentionally a minimal, explicit allowlist rather than a
+# passthrough to any ``pd.read_*`` method. Formats such as ``pickle`` and
+# ``hdf`` are excluded because loading them can execute arbitrary code
+# embedded in the file during deserialization. Additional safe, data-only
+# formats can be added in the future as needed.
+SUPPORTED_FILE_FORMATS = ("csv", "json", "parquet")
+
 
 class Tabular(AnomalibDataModule):
     """Tabular DataModule.
@@ -179,15 +188,27 @@ class Tabular(AnomalibDataModule):
                 especially when logging/saving.
             file_path (str | Path): Path to tabular file containing the datset
                 information.
-            file_format (str): File format supported by a pd.read_* method, such
-                as ``csv``, ``parquet`` or ``json``.
-                Defaults to ``None`` (inferred from file suffix).
+            file_format (str): File format of the tabular file. Must be one of
+                ``csv``, ``json`` or ``parquet`` (case-insensitive).
+                Defaults to ``None`` (inferred from the file suffix).
             pd_kwargs (dict | None): Keyword argument dictionary for the pd.read_* method.
                 Defaults to ``None``.
             kwargs (dict): Additional keyword arguments for the Tabular Datamodule class.
 
         Returns:
             Tabular: Tabular Datamodule
+
+        Raises:
+            FileNotFoundError: If ``file_path`` does not point to an existing file.
+            ValueError: If ``file_format`` is not specified and cannot be inferred from
+                the file name, or if it is not one of the supported formats.
+
+        Note:
+            Only the ``csv``, ``json`` and ``parquet`` formats are supported. Other
+            ``pandas`` readers, such as ``pickle`` or ``hdf``, are intentionally not
+            supported because loading them can execute arbitrary code embedded in the
+            file during deserialization. To load data from such a format, read it into
+            a ``DataFrame`` yourself and pass it to the ``Tabular`` constructor instead.
 
         Example:
             Prepare a tabular file (such as ``samples.csv`` or ``samples.parquet``) with the
@@ -223,14 +244,20 @@ class Tabular(AnomalibDataModule):
             raise FileNotFoundError(msg)
 
         # Infer file_format and check if supported
-        file_format = file_format or Path(file_path).suffix[1:]
+        file_format = (file_format or Path(file_path).suffix[1:]).lower()
         if not file_format:
             msg = f"File format not specified and could not be inferred from file name: '{Path(file_path).name}'"
             raise ValueError(msg)
-        read_func = getattr(pd, f"read_{file_format}", None)
-        if read_func is None:
-            msg = f"Unsupported file format: '{file_format}'"
+        if file_format not in SUPPORTED_FILE_FORMATS:
+            msg = (
+                f"Unsupported file format: '{file_format}'. "
+                f"Supported formats are: {', '.join(SUPPORTED_FILE_FORMATS)}. "
+                "Formats such as 'pickle' and 'hdf' are not supported because loading "
+                "them can execute arbitrary code. To use such a file, load it yourself "
+                "and pass the resulting DataFrame to the Tabular constructor instead."
+            )
             raise ValueError(msg)
+        read_func = getattr(pd, f"read_{file_format}")
 
         # Read the file and return Tabular dataset
         pd_kwargs = pd_kwargs or {}

--- a/tests/unit/data/datamodule/image/test_tabular.py
+++ b/tests/unit/data/datamodule/image/test_tabular.py
@@ -1,8 +1,9 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2025-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 """Unit Tests - Tabular Datamodule."""
 
+import pickle  # noqa: S403
 import tempfile
 from pathlib import Path
 
@@ -12,6 +13,16 @@ from torchvision.transforms.v2 import Resize
 
 from anomalib.data import Folder, Tabular
 from tests.unit.data.datamodule.base.image import _TestAnomalibImageDatamodule
+
+
+class _EvilPicklePayload:
+    """Pickle payload that writes a marker file when deserialized."""
+
+    def __init__(self, marker: Path) -> None:
+        self._marker = marker
+
+    def __reduce__(self) -> tuple:
+        return (Path(self._marker).write_text, ("pwned",))
 
 
 class TestTabular(_TestAnomalibImageDatamodule):
@@ -103,3 +114,71 @@ class TestTabularFromFile(TestTabular):
             datamodule_.setup()
 
         return datamodule_
+
+
+class TestTabularFromFileFormatValidation:
+    """Tests for the file format allowlist in ``Tabular.from_file``.
+
+    Regression tests for an ``insecure deserialization`` issue where
+    ``Tabular.from_file`` resolved the pandas reader via
+    ``getattr(pd, f"read_{file_format}")`` with no allowlist, allowing formats
+    such as ``pickle`` and ``hdf`` to be selected. Loading a malicious
+    ``*.pickle`` "dataset table" via the documented ``Tabular.from_file`` API
+    executed arbitrary code embedded in the file during deserialization.
+    """
+
+    @staticmethod
+    def test_missing_file_raises() -> None:
+        """A non-existent file should raise FileNotFoundError before any format check."""
+        with pytest.raises(FileNotFoundError):
+            Tabular.from_file(name="dummy", file_path="/no/such/file.csv")
+
+    @staticmethod
+    def test_rejects_pickle_suffix_without_executing_payload(tmp_path: Path) -> None:
+        """A malicious ``.pickle`` file must be rejected without being deserialized."""
+        marker = tmp_path / "PWNED.txt"
+        evil_path = tmp_path / "samples.pickle"
+        with evil_path.open("wb") as f:
+            pickle.dump(_EvilPicklePayload(marker), f)
+
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            Tabular.from_file(name="dummy", file_path=str(evil_path))
+
+        assert not marker.exists(), "Payload was executed: pickle file must not be deserialized"
+
+    @staticmethod
+    @pytest.mark.parametrize("file_format", ["pickle", "hdf", "xml", "html", "clipboard", "sql"])
+    def test_rejects_dangerous_explicit_format(tmp_path: Path, file_format: str) -> None:
+        """Explicitly requesting a disallowed format must also be rejected."""
+        csv_path = tmp_path / "samples.csv"
+        pd.DataFrame({"image_path": ["a.png"]}).to_csv(csv_path)
+
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            Tabular.from_file(name="dummy", file_path=str(csv_path), file_format=file_format)
+
+    @staticmethod
+    def test_rejects_unknown_format(tmp_path: Path) -> None:
+        """An unrecognized file suffix should raise a clear ValueError."""
+        txt_path = tmp_path / "samples.txt"
+        txt_path.write_text("not a real dataset table")
+
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            Tabular.from_file(name="dummy", file_path=str(txt_path))
+
+    @staticmethod
+    def test_rejects_missing_format(tmp_path: Path) -> None:
+        """A file with no suffix and no explicit file_format should raise ValueError."""
+        no_suffix_path = tmp_path / "samples"
+        no_suffix_path.write_text("image_path\n")
+
+        with pytest.raises(ValueError, match="File format not specified"):
+            Tabular.from_file(name="dummy", file_path=str(no_suffix_path))
+
+    @staticmethod
+    def test_format_is_case_insensitive(tmp_path: Path) -> None:
+        """Format inference from the suffix should be case-insensitive."""
+        csv_path = tmp_path / "samples.CSV"
+        pd.DataFrame({"image_path": ["a.png"]}).to_csv(csv_path)
+
+        datamodule_ = Tabular.from_file(name="dummy", file_path=str(csv_path))
+        assert isinstance(datamodule_, Tabular)

--- a/tests/unit/data/datamodule/image/test_tabular.py
+++ b/tests/unit/data/datamodule/image/test_tabular.py
@@ -139,7 +139,7 @@ class TestTabularFromFileFormatValidation:
         marker = tmp_path / "PWNED.txt"
         evil_path = tmp_path / "samples.pickle"
         with evil_path.open("wb") as f:
-            pickle.dump(_EvilPicklePayload(marker), f)
+            pickle.dump(_EvilPicklePayload(marker), f)  # nosemgrep
 
         with pytest.raises(ValueError, match="Unsupported file format"):
             Tabular.from_file(name="dummy", file_path=str(evil_path))


### PR DESCRIPTION
## 📝 Description

- 🛠️ Fixes VUL0008052

### Original Security Report (truncated)

### Root cause

The method's own docstring advertises only safe, data-only formats ("*File format supported by a pd.read_* method, such as `csv`, `parquet` or `json`*"). But `getattr(pd, f"read_{file_format}")` places **no allowlist** on which reader is selected, so it also resolves `read_pickle`, `read_hdf`, `read_xml`, etc. In particular a file named `samples.pickle` yields `file_format = "pickle"` → `pd.read_pickle(file_path)`, which **unpickles** the file. Python pickle deserialization executes arbitrary code embedded via `__reduce__` **during** the load, before any DataFrame validation. There is no trust gate, no safe-loader restriction, and no format allowlist.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [ ] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [x] 🔒 Security update
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
