### PR TITLE
fix(ci): bump twine to 7.0.0 to support metadata-version 2.5

### DIFF
--- a/.github/workflows/_reusable-artifact-builder.yaml
+++ b/.github/workflows/_reusable-artifact-builder.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Verify package
         if: inputs.verify-package
         run: |
-          python -m pip install twine==6.2.0
+          python -m pip install twine==7.0.0
           twine check dist/*
       - name: Set artifact name
         id: set-artifact-name


### PR DESCRIPTION
## 📝 Description

- twine 6.2.0 hardcodes a max supported metadata version of 2.4, causing 'twine check' to fail with InvalidDistribution once hatchling >=1.27 emits Metadata-Version: 2.5.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔄 Refactor (non-breaking change which refactors the code base)
- [ ] ⚡ Performance improvements
- [ ] 🎨 Style changes (code style/formatting)
- [ ] 🧪 Tests (adding/modifying tests)
- [ ] 📚 Documentation update
- [ ] 📦 Build system changes
- [x] 🚧 CI/CD configuration
- [ ] 🔧 Chore (general maintenance)
- [ ] 🔒 Security update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
- [x] 🏷️ My PR title follows conventional commit format.

For more information about code review checklists, see the [Code Review Checklist](https://github.com/open-edge-platform/anomalib/blob/main/docs/source/markdown/guides/developer/contributing.md).
